### PR TITLE
Update ngiab

### DIFF
--- a/docker/Dockerfile.datastream
+++ b/docker/Dockerfile.datastream
@@ -1,5 +1,5 @@
 ARG TAG_NAME
-FROM datastream-deps:${TAG_NAME} as datastream_base
+FROM awiciroh/datastream-deps:${TAG_NAME} as datastream_base
 RUN git clone https://github.com/CIROH-UA/ngen-datastream.git
 RUN pip3 install -e "/ngen-datastream/python"
 

--- a/docker/Dockerfile.forcingprocessor
+++ b/docker/Dockerfile.forcingprocessor
@@ -1,5 +1,5 @@
 ARG TAG_NAME
-FROM datastream-deps:${TAG_NAME} as datastream_base
+FROM awiciroh/datastream-deps:${TAG_NAME} as datastream_base
 RUN git clone https://github.com/CIROH-UA/ngen-datastream.git
 RUN pip install -r /ngen-datastream/forcingprocessor/requirements39.txt
 

--- a/scripts/docker_builds.sh
+++ b/scripts/docker_builds.sh
@@ -14,10 +14,9 @@ done
 
 DATASTREAM_DOCKER="$DATASTREAM_PATH"/docker
 cd $DATASTREAM_DOCKER
-docker build -t datastream-deps:latest -f Dockerfile.datastream-deps . --no-cache --build-arg TAG_NAME=latest --build-arg ARCH=$(uname -m) && \
-docker build -t forcingprocessor:latest -f Dockerfile.forcingprocessor . --no-cache --build-arg TAG_NAME=latest && \
-    docker build -t datastream:latest -f Dockerfile.datastream . --no-cache --build-arg TAG_NAME=latest 
-
+docker build -t awiciroh/datastream-deps:latest -f Dockerfile.datastream-deps . --no-cache --build-arg TAG_NAME=latest --build-arg ARCH=$(uname -m) --platform linux/$(uname -m) && \
+docker build -t awiciroh/forcingprocessor:latest -f Dockerfile.forcingprocessor . --no-cache --build-arg TAG_NAME=latest --platform linux/$(uname -m) && \
+    docker build -t awiciroh/datastream:latest -f Dockerfile.datastream . --no-cache --build-arg TAG_NAME=latest --platform linux/$(uname -m)
 
 NGIAB_PATH="$DATASTREAM_PATH"/NGIAB-CloudInfra
 NGIAB_DOCKER="$NGIAB_PATH"/docker

--- a/scripts/docker_builds.sh
+++ b/scripts/docker_builds.sh
@@ -11,21 +11,26 @@ while [ "$#" -gt 0 ]; do
         *) usage;;
     esac
 done        
-
+PLATFORM=$(uname -m)
+PLATORM_TAG=""
+if [ $PLATFORM = "x86_64" ]; then
+    PLATORM_TAG="-x86"
+fi
+TAG="latest$PLATORM_TAG"
 DATASTREAM_DOCKER="$DATASTREAM_PATH"/docker
 cd $DATASTREAM_DOCKER
-docker build -t awiciroh/datastream-deps:latest -f Dockerfile.datastream-deps . --no-cache --build-arg TAG_NAME=latest --build-arg ARCH=$(uname -m) --platform linux/$(uname -m) && \
-docker build -t awiciroh/forcingprocessor:latest -f Dockerfile.forcingprocessor . --no-cache --build-arg TAG_NAME=latest --platform linux/$(uname -m) && \
-    docker build -t awiciroh/datastream:latest -f Dockerfile.datastream . --no-cache --build-arg TAG_NAME=latest --platform linux/$(uname -m)
+docker build -t awiciroh/datastream-deps:$TAG -f Dockerfile.datastream-deps . --no-cache --build-arg TAG_NAME=$TAG --build-arg ARCH=$PLATFORM --platform linux/$PLATFORM 
+docker build -t awiciroh/forcingprocessor:$TAG -f Dockerfile.forcingprocessor . --no-cache --build-arg TAG_NAME=$TAG --platform linux/$PLATFORM
+docker build -t awiciroh/datastream:$TAG -f Dockerfile.datastream . --no-cache --build-arg TAG_NAME=$TAG --platform linux/$PLATFORM
 
 NGIAB_PATH="$DATASTREAM_PATH"/NGIAB-CloudInfra
 NGIAB_DOCKER="$NGIAB_PATH"/docker
 git submodule init
 git submodule update
 cd $NGIAB_DOCKER
-docker build -t awiciroh/ngen-deps:latest -f Dockerfile.ngen-deps --no-cache . && \
-    docker build -t awiciroh/t-route:latest -f ./Dockerfile.t-route . --no-cache --build-arg TAG_NAME=latest && \
-    docker build -t awiciroh/ngen:latest -f ./Dockerfile.ngen . --no-cache --build-arg TAG_NAME=latest && \
-    docker build -t awiciroh/ciroh-ngen-image:latest -f ./Dockerfile . --no-cache --build-arg TAG_NAME=latest 
+docker build -t awiciroh/ngen-deps:$TAG -f Dockerfile.ngen-deps --no-cache . && \
+    docker build -t awiciroh/t-route:$TAGG -f ./Dockerfile.t-route . --no-cache --build-arg TAG_NAME=$TAG && \
+    docker build -t awiciroh/ngen:$TAG-f ./Dockerfile.ngen . --no-cache --build-arg TAG_NAME=$TAG && \
+    docker build -t awiciroh/ciroh-ngen-image:$TAG -f ./Dockerfile . --no-cache --build-arg TAG_NAME=$TAG
 
 echo "done!"    

--- a/scripts/docker_builds.sh
+++ b/scripts/docker_builds.sh
@@ -29,7 +29,7 @@ git submodule init
 git submodule update
 cd $NGIAB_DOCKER
 docker build -t awiciroh/ngen-deps:$TAG -f Dockerfile.ngen-deps --no-cache . && \
-    docker build -t awiciroh/t-route:$TAGG -f ./Dockerfile.t-route . --no-cache --build-arg TAG_NAME=$TAG && \
+    docker build -t awiciroh/t-route:$TAG -f ./Dockerfile.t-route . --no-cache --build-arg TAG_NAME=$TAG && \
     docker build -t awiciroh/ngen:$TAG-f ./Dockerfile.ngen . --no-cache --build-arg TAG_NAME=$TAG && \
     docker build -t awiciroh/ciroh-ngen-image:$TAG -f ./Dockerfile . --no-cache --build-arg TAG_NAME=$TAG
 

--- a/scripts/stream.sh
+++ b/scripts/stream.sh
@@ -89,6 +89,11 @@ HOST_OS=$(cat /etc/os-release | grep "PRETTY_NAME")
 HOST_OS=$(echo "$HOST_OS" | sed 's/.*"\(.*\)"/\1/')
 echo "HOST_OS" $HOST_OS
 
+PLATORM_TAG=""
+if [ $(uname -m) = "x86_64" ]; then
+    PLATORM_TAG="-x86"
+fi
+
 # read cli args
 while [ "$#" -gt 0 ]; do
     case "$1" in
@@ -362,11 +367,11 @@ if [ -z $FORCINGS_TAR ]; then
         log_time "WEIGHTS_START" $DATASTREAM_PROFILING
         echo "Weights file not found. Creating from" $GEO_BASE
         GEO_PATH_DOCKER=""$DOCKER_RESOURCES"/ngen-configs/$GEO_BASE"
-        DOCKER_TAG="awiciroh/forcingprocessor:latest"
         WEIGHTS_DOCKER=""$DOCKER_RESOURCES"/weights.json"
-        docker run -v "$DATA_PATH:"$DOCKER_MOUNT"" $DOCKER_TAG\
+        DOCKER_TAG="awiciroh/forcingprocessor:latest$PLATORM_TAG"
+        docker run -v "$DATA_PATH:"$DOCKER_MOUNT"" \
             -u $(id -u):$(id -g) \
-            -w "$DOCKER_MOUNT" forcingprocessor \
+            -w "$DOCKER_MOUNT" $DOCKER_TAG \
             python "$DOCKER_FP_PATH"weights_parq2json.py \
             --gpkg $GEO_PATH_DOCKER --outname $WEIGHTS_DOCKER --nprocs $NPROCS
         log_time "WEIGHTS_END" $DATASTREAM_PROFILING
@@ -374,7 +379,7 @@ if [ -z $FORCINGS_TAR ]; then
 fi
 
 log_time "DATASTREAMCONFGEN_START" $DATASTREAM_PROFILING
-DOCKER_TAG="awiciroh/datastream:latest"
+DOCKER_TAG="awiciroh/datastream:latest$PLATORM_TAG"
 echo "Generating ngen-datastream metadata"
 CONFIGURER="/ngen-datastream/python/src/datastream/configure-datastream.py"
 docker run --rm -v "$DATA_PATH":"$DOCKER_MOUNT" $DOCKER_TAG \
@@ -414,7 +419,7 @@ if [ ! -z $FORCINGS_TAR ]; then
 else
     log_time "FORCINGPROCESSOR_START" $DATASTREAM_PROFILING
     echo "Creating nwm filenames file"
-    DOCKER_TAG="awiciroh/forcingprocessor:latest"
+    DOCKER_TAG="awiciroh/forcingprocessor:latest$PLATORM_TAG"
     docker run --rm -v "$DATA_PATH:"$DOCKER_MOUNT"" \
         -u $(id -u):$(id -g) \
         -w "$DOCKER_RESOURCES" $DOCKER_TAG \
@@ -432,7 +437,7 @@ fi
 
 log_time "VALIDATION_START" $DATASTREAM_PROFILING
 VALIDATOR="/ngen-datastream/python/src/datastream/run_validator.py"
-DOCKER_TAG="awiciroh/datastream:latest"
+DOCKER_TAG="awiciroh/datastream:latest$PLATORM_TAG"
 echo "Validating " $NGEN_RUN_PATH
 docker run --rm -v "$NGEN_RUN_PATH":"$DOCKER_MOUNT" \
     $DOCKER_TAG python $VALIDATOR \
@@ -441,7 +446,7 @@ log_time "VALIDATION_END" $DATASTREAM_PROFILING
 
 log_time "NGEN_START" $DATASTREAM_PROFILING
 echo "Running NextGen in AUTO MODE from CIROH-UA/NGIAB-CloudInfra"
-docker run --rm -v "$NGEN_RUN_PATH":"$DOCKER_MOUNT" awiciroh/ciroh-ngen-image:latest "$DOCKER_MOUNT" auto $NPROCS
+docker run --rm -v "$NGEN_RUN_PATH":"$DOCKER_MOUNT" awiciroh/ciroh-ngen-image:latest$PLATORM_TAG "$DOCKER_MOUNT" auto $NPROCS
 log_time "NGEN_END" $DATASTREAM_PROFILING
 
 cp -r $NGEN_RUN_PATH/*partitions* $DATASTREAM_RESOURCES/

--- a/scripts/stream.sh
+++ b/scripts/stream.sh
@@ -362,8 +362,9 @@ if [ -z $FORCINGS_TAR ]; then
         log_time "WEIGHTS_START" $DATASTREAM_PROFILING
         echo "Weights file not found. Creating from" $GEO_BASE
         GEO_PATH_DOCKER=""$DOCKER_RESOURCES"/ngen-configs/$GEO_BASE"
+        DOCKER_TAG="awiciroh/forcingprocessor:latest"
         WEIGHTS_DOCKER=""$DOCKER_RESOURCES"/weights.json"
-        docker run -v "$DATA_PATH:"$DOCKER_MOUNT"" \
+        docker run -v "$DATA_PATH:"$DOCKER_MOUNT"" $DOCKER_TAG\
             -u $(id -u):$(id -g) \
             -w "$DOCKER_MOUNT" forcingprocessor \
             python "$DOCKER_FP_PATH"weights_parq2json.py \
@@ -373,7 +374,7 @@ if [ -z $FORCINGS_TAR ]; then
 fi
 
 log_time "DATASTREAMCONFGEN_START" $DATASTREAM_PROFILING
-DOCKER_TAG="datastream:latest"
+DOCKER_TAG="awiciroh/datastream:latest"
 echo "Generating ngen-datastream metadata"
 CONFIGURER="/ngen-datastream/python/src/datastream/configure-datastream.py"
 docker run --rm -v "$DATA_PATH":"$DOCKER_MOUNT" $DOCKER_TAG \
@@ -413,7 +414,7 @@ if [ ! -z $FORCINGS_TAR ]; then
 else
     log_time "FORCINGPROCESSOR_START" $DATASTREAM_PROFILING
     echo "Creating nwm filenames file"
-    DOCKER_TAG="forcingprocessor:latest"
+    DOCKER_TAG="awiciroh/forcingprocessor:latest"
     docker run --rm -v "$DATA_PATH:"$DOCKER_MOUNT"" \
         -u $(id -u):$(id -g) \
         -w "$DOCKER_RESOURCES" $DOCKER_TAG \
@@ -431,7 +432,7 @@ fi
 
 log_time "VALIDATION_START" $DATASTREAM_PROFILING
 VALIDATOR="/ngen-datastream/python/src/datastream/run_validator.py"
-DOCKER_TAG="datastream:latest"
+DOCKER_TAG="awiciroh/datastream:latest"
 echo "Validating " $NGEN_RUN_PATH
 docker run --rm -v "$NGEN_RUN_PATH":"$DOCKER_MOUNT" \
     $DOCKER_TAG python $VALIDATOR \


### PR DESCRIPTION
This updates NGIAB to a commit that fixes https://github.com/CIROH-UA/NGIAB-CloudInfra/issues/154 . stream.sh will now pull the docker images from DockerHub as opposed to requiring a local build. The docker tag convention in this merge to denote image platform is not the recommended method (manifests are suggested in the specs), but matches the current tag convention that NGIAB uses. https://github.com/CIROH-UA/NGIAB-CloudInfra/issues/158 