### PR TITLE
allow forcing path

### DIFF
--- a/forcingprocessor/README.md
+++ b/forcingprocessor/README.md
@@ -37,7 +37,7 @@ See the docker README for example run commands from the container.
 ### 1. Forcing
 | Field             | Description              | Required |
 |-------------------|--------------------------|----------|
-| nwm_file          | Path to a text file containing nwm file names. One filename per line. [Tool](#nwm_file) to create this file | :white_check_mark: |
+| nwm_file          | Path to a text file containing nwm file names. One filename per line [Tool](#nwm_file) to create this file. OR path to local directory hold forcing files  | :white_check_mark: |
 | weight_file       | Weight file for the run Accepts local absolute path, s3 URI or URL. [Tool](#weight_file) to create this file |  :white_check_mark: |
 
 ### 2. Storage

--- a/forcingprocessor/src/forcingprocessor/forcingprocessor.py
+++ b/forcingprocessor/src/forcingprocessor/forcingprocessor.py
@@ -866,11 +866,16 @@ def prep_ngen_data(conf):
     x_max=np.max(x_max_list)   
     y_min=np.min(y_min_list)   
     y_max=np.max(y_max_list)          
-
+    
     nwm_forcing_files = []
-    with open(nwm_file,'r') as fp:
-        for jline in fp.readlines():
-            nwm_forcing_files.append(jline.strip())
+    if os.path.isdir(nwm_file):
+        rel_files = os.listdir(nwm_file)
+        for jfile in rel_files:
+            nwm_forcing_files.append(os.path.join(nwm_file,jfile))
+    else:
+        with open(nwm_file,'r') as fp:
+            for jline in fp.readlines():
+                nwm_forcing_files.append(jline.strip())
     nfiles = len(nwm_forcing_files)
 
     # memory_check(nwm_forcing_files, weight_files, ncatchments)


### PR DESCRIPTION
This PR implements the ability to provide forcingprocessor a path to a directory holding local forcing files. Previously, the user would need to create a text file that held each of the forcing file paths/urls. Now, If `nwm_file` is set to a local path, forcingprocessor will walk the directory and process every file it finds.