### PR TITLE
feat: allow for nwm forcings in resource directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,23 +12,23 @@
 
 Usage: ./ngen-datastream/scripts/stream.sh [options]
 Either provide a datastream configuration file
-  -c, --CONF_FILE          <Path to datastream configuration file>
+  -c, --CONF_FILE           <Path to datastream configuration file> 
 or run with cli args
-  -s, --START_DATE          <YYYYMMDDHHMM or "DAILY">
-  -e, --END_DATE            <YYYYMMDDHHMM>
-  -d, --DATA_PATH           <Path to write to>
-  -R, --REALIZATION         <Path to realization file>
-  -r, --RESOURCE_PATH       <Path to resource directory>
-  -f, --FORCINGS_TAR        <Path to forcings tarball> 
-  -g, --GEOPACAKGE          <Path to geopackage file>
-  -G, --GEOPACKAGE_ATTR     <Path to geopackage attributes file>
-  -S, --S3_MOUNT            <Path to mount s3 bucket to>
+  -s, --START_DATE          <YYYYMMDDHHMM or "DAILY"> 
+  -e, --END_DATE            <YYYYMMDDHHMM> 
+  -D, --DOMAIN_NAME         <Name for spatial domain> 
+  -g, --GEOPACAKGE          <Path to geopackage file> 
+  -G, --GEOPACKAGE_ATTR     <Path to geopackage attributes file> 
+  -i, --SUBSET_ID_TYPE      <Hydrofabric id type>  
+  -I, --SUBSET_ID           <Hydrofabric id to subset>  
+  -v, --HYDROFABRIC_VERSION <Hydrofabric version> 
+  -R, --REALIZATION         <Path to realization file> 
+  -d, --DATA_PATH           <Path to write to> 
+  -r, --RESOURCE_PATH       <Path to resource directory> 
+  -f, --FORCINGS            <Path to forcings directory or tarball> 
+  -S, --S3_MOUNT            <Path to mount s3 bucket to>  
   -o, --S3_PREFIX           <File prefix within s3 mount>
-  -i, --SUBSET_ID_TYPE      <Hydrofabric id type>
-  -I, --SUBSET_ID           <Hydrofabric id to subset>
-  -v, --HYDROFABRIC_VERSION <Hydrofabric version>
-  -n, --NPROCS              <Process limit>
-  -D, --DOMAIN_NAME         <Name for spatial domain>
+  -n, --NPROCS              <Process limit> 
 ```
 This command will execute a 24 hour NextGen simulation over VPU 09 with CFE, SLOTH, PET, and NOM configuration distributed over 8 processes. See more [examples](https://github.com/CIROH-UA/ngen-datastream/blob/main/examples).
 ```
@@ -47,19 +47,19 @@ This command will execute a 24 hour NextGen simulation over VPU 09 with CFE, SLO
 |---------------------|--------------------------|------|
 | START_DATE          | Start simulation time (YYYYMMDDHHMM) or "DAILY" | :white_check_mark: |
 | END_DATE            | End simulation time  (YYYYMMDDHHMM) | :white_check_mark: |
-| DATA_PATH           | Absolute local path to construct the datastream run. | :white_check_mark: |
-| REALIZATION         | Path to NextGen realization file | Required here or file exists in `RESOURCE_PATH/ngen-configs` |
+| DOMAIN_NAME         | Name for spatial domain in run, stripped from gpkg if not supplied |  |
 | GEOPACKAGE          | Path to hydrofabric, can be s3URI, URL, or local file | Required here or file exists in `RESOURCE_PATH/ngen-configs` |
 | GEOPACKAGE_ATTR     | Path to hydrofabric attributes, can be s3URI, URL, or local file | Required here or file exists in `RESOURCE_PATH/ngen-configs` |
-| RESOURCE_PATH       | Path to directory that contains the datastream resources. This directory allows the user to place the several required files into a single directory and simply point `ngen-datastream` to it. This is folder is generated at `DATA_PATH/datastream-resources` during a `ngen-datastream` execution and can be reused in future runs. More explanation [here](#datastream-resources)|  |
-| FORCINGS_TAR            | Path to tarball that contains forcings csvs or parquets|  |
-| S3_MOUNT            | Path to mount S3 bucket to. `ngen-datastream` will copy outputs here. |  |
-| S3_PREFIX           | Prefix to prepend to all files when copying to s3 |
 | SUBSET_ID_TYPE      | id type corresponding to "id" [See hfsubset for options](https://github.com/LynkerIntel/hfsubset?tab=readme-ov-file#cli-option) |   |
 | SUBSET_ID           | catchment id to subset [See hfsubset for options](https://github.com/LynkerIntel/hfsubset?tab=readme-ov-file#cli-option) |   |
 | HYDROFABRIC_VERSION | $\geq$ v20.1 [See hfsubset for options](https://github.com/LynkerIntel/hfsubset?tab=readme-ov-file#cli-option)  |
+| REALIZATION         | Path to NextGen realization file | Required here or file exists in `RESOURCE_PATH/ngen-configs` |
+| DATA_PATH           | Absolute local path to construct the datastream run. | :white_check_mark: |
+| RESOURCE_PATH       | Path to directory that contains the datastream resources. This directory allows the user to place the several required files into a single directory and simply point `ngen-datastream` to it. This is folder is generated at `DATA_PATH/datastream-resources` during a `ngen-datastream` execution and can be reused in future runs. More explanation [here](#datastream-resources)|  |
+| FORCINGS            | Path to local directory containing nwm files or tarball that contains ngen forcings csvs/parquets|  |
+| S3_MOUNT            | Path to mount S3 bucket to. `ngen-datastream` will copy outputs here. |  |
+| S3_PREFIX           | Prefix to prepend to all files when copying to s3 |
 | NPROCS              | Maximum number of processes to use in any step of  `ngen-datastream`. Defaults to `nprocs - 2` |  |
-| DOMAIN_NAME         | Name for spatial domain in run, stripped from gpkg if not supplied |  |
 
 
 
@@ -107,6 +107,8 @@ The easiest way to create a reusable resource directory is to execute `ngen-data
 ```
 RESOURCE_PATH/
 |
+├── weights.json
+|
 ├── ngen-configs/
 |   │
 |   ├── nextgen_01.gpkg
@@ -117,7 +119,9 @@ RESOURCE_PATH/
 |   │
 |   ├── ngen-bmi-configs.tar.gz
 |
-├── weights.json
+├── nwm-forcings/
+|   ├── nwm.t00z.medium_range.forcing.f001.conus
+|   ├── ...
   
 ```
 

--- a/python/src/datastream/configure-datastream.py
+++ b/python/src/datastream/configure-datastream.py
@@ -99,8 +99,6 @@ def create_conf_fp(start,end,nprocs,docker_mount,forcing_split_vpu,retro_or_op):
 
     fp_conf = {
         "forcing" : {
-            "start_date"   : start,
-            "end_date"     : end,
             "nwm_file"     : f"{docker_mount}/datastream-metadata/{filename}",
             "weight_file"  : weights,
         },

--- a/scripts/stream.sh
+++ b/scripts/stream.sh
@@ -40,23 +40,23 @@ usage() {
     echo ""
     echo "Usage: $0 [options]"
     echo "Either provide a datastream configuration file"
-    echo "  -c, --CONF_FILE          <Path to datastream configuration file> "  
+    echo "  -c, --CONF_FILE           <Path to datastream configuration file> "  
     echo "or run with cli args"
     echo "  -s, --START_DATE          <YYYYMMDDHHMM or \"DAILY\"> "
     echo "  -e, --END_DATE            <YYYYMMDDHHMM> "
-    echo "  -d, --DATA_PATH           <Path to write to> "
-    echo "  -R, --REALIZATION         <Path to realization file> "
-    echo "  -r, --RESOURCE_PATH       <Path to resource directory> "
-    echo "  -f, --FORCINGS_TAR        <Path to forcings tarball> "
+    echo "  -D, --DOMAIN_NAME         <Name for spatial domain> "    
     echo "  -g, --GEOPACAKGE          <Path to geopackage file> "
-    echo "  -G, --GEOPACKAGE_ATTR     <Path to geopackage attributes file> "
-    echo "  -S, --S3_MOUNT            <Path to mount s3 bucket to>  "
-    echo "  -o, --S3_PREFIX           <File prefix within s3 mount>"
+    echo "  -G, --GEOPACKAGE_ATTR     <Path to geopackage attributes file> "  
     echo "  -i, --SUBSET_ID_TYPE      <Hydrofabric id type>  "   
     echo "  -I, --SUBSET_ID           <Hydrofabric id to subset>  "
-    echo "  -v, --HYDROFABRIC_VERSION <Hydrofabric version> "
+    echo "  -v, --HYDROFABRIC_VERSION <Hydrofabric version> "      
+    echo "  -R, --REALIZATION         <Path to realization file> "  
+    echo "  -d, --DATA_PATH           <Path to write to> "
+    echo "  -r, --RESOURCE_PATH       <Path to resource directory> "
+    echo "  -f, --FORCINGS            <Path to forcings directory or tarball> "
+    echo "  -S, --S3_MOUNT            <Path to mount s3 bucket to>  "
+    echo "  -o, --S3_PREFIX           <File prefix within s3 mount>"
     echo "  -n, --NPROCS              <Process limit> "
-    echo "  -D, --DOMAIN_NAME         <Name for spatial domain> "
     exit 1
 }
 
@@ -66,7 +66,7 @@ END_DATE=""
 DATA_PATH=""
 REALIZATION=""
 RESOURCE_PATH=""
-FORCINGS_TAR=""
+FORCINGS=""
 GEOPACKAGE=""
 GEOPACKAGE_ATTR=""
 S3_MOUNT=""
@@ -102,7 +102,7 @@ while [ "$#" -gt 0 ]; do
         -d|--DATA_PATH) DATA_PATH="$2"; shift 2;;
         -R|--REALIZATION) REALIZATION="$2"; shift 2;;
         -r|--RESOURCE_PATH) RESOURCE_PATH="$2"; shift 2;;
-        -f|--FORCINGS_TAR) FORCINGS_TAR="$2"; shift 2;;
+        -f|--FORCINGS) FORCINGS="$2"; shift 2;;
         -g|--GEOPACKAGE) GEOPACKAGE="$2"; shift 2;;
         -G|--GEOPACKAGE_ATTR) GEOPACKAGE_ATTR="$2"; shift 2;;
         -S|--S3_MOUNT) S3_MOUNT="$2"; shift 2;;
@@ -219,6 +219,16 @@ DOCKER_RESOURCES="${DOCKER_MOUNT%/}/datastream-resources"
 DOCKER_META="${DOCKER_MOUNT%/}/datastream-metadata"
 DOCKER_FP_PATH="/ngen-datastream/forcingprocessor/src/forcingprocessor/"
 
+FORCINGS_TAR=""
+FORCINGS_LOCAL_DIRECTORY=""
+if [[ $FORCINGS =~ \.tar\.gz$ ]]; then
+    echo "Provided forcings tarball"
+    FORCINGS_TAR=$FORCINGS
+else
+    echo "Provided local forcings directory"
+    FORCINGS_LOCAL_DIRECTORY=$FORCINGS
+fi
+
 log_time "GET_RESOURCES_START" $DATASTREAM_PROFILING
 if [ ! -z $RESOURCE_PATH ]; then
     echo "running in lite mode"
@@ -275,6 +285,9 @@ if [ ! -z $RESOURCE_PATH ]; then
         echo "geopackage missing from resources"     
         exit 1   
     fi
+
+    # Look for local nwm forcings
+    FORCINGS_LOCAL_DIRECTORY=$(find $RESOURCE_PATH -type d -name "nwm-forcings")
 
     # Look for geopackage attributes file
     # HACK: Should look for this in another way. Right now, this is the only parquet, but seems dangerous
@@ -420,12 +433,32 @@ else
     log_time "FORCINGPROCESSOR_START" $DATASTREAM_PROFILING
     echo "Creating nwm filenames file"
     DOCKER_TAG="awiciroh/forcingprocessor:latest$PLATORM_TAG"
-    docker run --rm -v "$DATA_PATH:"$DOCKER_MOUNT"" \
-        -u $(id -u):$(id -g) \
-        -w "$DOCKER_RESOURCES" $DOCKER_TAG \
-        python "$DOCKER_FP_PATH"nwm_filenames_generator.py \
-        "$DOCKER_MOUNT"/datastream-metadata/conf_nwmurl.json
-    cp -v -t $DATASTREAM_META_PATH $DATASTREAM_RESOURCES/*filenamelist.txt
+    if [ ! -z $FORCINGS_LOCAL_DIRECTORY ]; then
+        FORCINGS_LOCAL_DIRECTORY=$(realpath "$FORCINGS_LOCAL_DIRECTORY")
+        LOCAL_FILENAMES="local_filenamelist.txt"
+        > "$LOCAL_FILENAMES"
+        find "$FORCINGS_LOCAL_DIRECTORY" -type f | sort >> "$LOCAL_FILENAMES"
+        mv $LOCAL_FILENAMES $DATASTREAM_RESOURCES
+
+        NWM_FORCINGS="/nwm-forcings"
+        FILENAMES="filenamelist.txt"
+        > "$FILENAMES"
+        find "$FORCINGS_LOCAL_DIRECTORY" -type f | sort | while read -r file; do
+            relative_path="${file#$FORCINGS_LOCAL_DIRECTORY}"
+            echo "$DOCKER_RESOURCES$NWM_FORCINGS$relative_path" >> "$FILENAMES"
+        done
+        mkdir -p $DATA_PATH$NWM_FORCINGS
+        echo "Copying nwm files into "$DATA_PATH$NWM_FORCINGS
+        cp -r $FORCINGS_LOCAL_DIRECTORY/* $DATASTREAM_RESOURCES$NWM_FORCINGS
+        cp $FILENAMES $DATASTREAM_META_PATH
+    else
+        docker run --rm -v "$DATA_PATH:"$DOCKER_MOUNT"" \
+            -u $(id -u):$(id -g) \
+            -w "$DOCKER_RESOURCES" $DOCKER_TAG \
+            python "$DOCKER_FP_PATH"nwm_filenames_generator.py \
+            "$DOCKER_MOUNT"/datastream-metadata/conf_nwmurl.json
+        cp -v -t $DATASTREAM_META_PATH $DATASTREAM_RESOURCES/*filenamelist.txt
+    fi
     echo "Creating forcing files"
     docker run --rm -v "$DATA_PATH:"$DOCKER_MOUNT"" \
         -u $(id -u):$(id -g) \
@@ -433,6 +466,10 @@ else
         python "$DOCKER_FP_PATH"forcingprocessor.py "$DOCKER_META"/conf_fp.json
     mv $DATASTREAM_RESOURCES/log_fp.txt $DATASTREAM_META_PATH 
     log_time "FORCINGPROCESSOR_END" $DATASTREAM_PROFILING
+    if [ ! -z $FORCINGS_LOCAL_DIRECTORY ]; then
+        rm $DATASTREAM_META_PATH/$FILENAMES
+        cp $DATASTREAM_RESOURCES/$LOCAL_FILENAMES $DATASTREAM_META_PATH
+    fi
 fi    
 
 log_time "VALIDATION_START" $DATASTREAM_PROFILING


### PR DESCRIPTION
previously ngen-datastream generated nwm forcings urls for the user based on the start and end times. however, the user may want to provide local nwm forcing files to avoid network bottle necks (especially during the devcon demo). This PR allows the user to provide the path to a directory holding the local nwm files via `FORCINGS` or store the forcings in the resource directory under `nwm-forcings`