### PR TITLE
revert fp python back to 3.9

### DIFF
--- a/.github/workflows/forcingprocessor_aws_sources.yaml
+++ b/.github/workflows/forcingprocessor_aws_sources.yaml
@@ -28,7 +28,7 @@ jobs:
     - name: Set up Python 3.12
       uses: actions/setup-python@v3
       with:
-        python-version: "3.12"
+        python-version: "3.9"
 
     - name: Configure AWS
       run: |

--- a/.github/workflows/forcingprocessor_gcs_sources.yaml
+++ b/.github/workflows/forcingprocessor_gcs_sources.yaml
@@ -25,10 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.12
+    - name: Set up Python 3.9
       uses: actions/setup-python@v3
       with:
-        python-version: "3.12"
+        python-version: "3.9"
 
     - name: Configure AWS
       run: |

--- a/.github/workflows/forcingprocessor_plotting.yaml
+++ b/.github/workflows/forcingprocessor_plotting.yaml
@@ -25,10 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.12
+    - name: Set up Python 3.9
       uses: actions/setup-python@v3
       with:
-        python-version: "3.12"
+        python-version: "3.9"
 
     - name: Configure AWS
       run: |

--- a/.github/workflows/forcingprocessor_weights.yaml
+++ b/.github/workflows/forcingprocessor_weights.yaml
@@ -25,10 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.12
+    - name: Set up Python 3.9
       uses: actions/setup-python@v3
       with:
-        python-version: "3.12"
+        python-version: "3.9"
 
     - name: Configure AWS
       run: |

--- a/forcingprocessor/setup.cfg
+++ b/forcingprocessor/setup.cfg
@@ -18,7 +18,7 @@ classifiers =
     Intended Audience :: Education
     Intended Audience :: Science/Research
     License :: Free To Use But Restricted
-    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.9
     Topic :: Scientific/Engineering :: Hydrology
     Operating System :: OS Independent
 
@@ -46,7 +46,7 @@ install_requires =
     scipy
     xarray
 
-python_requires = >=3.12
+python_requires = >=3.9
 include_package_data = True
 
 [options.packages.find]

--- a/forcingprocessor/src/forcingprocessor/processor.py
+++ b/forcingprocessor/src/forcingprocessor/processor.py
@@ -10,7 +10,7 @@ import time
 import boto3
 from io import BytesIO, TextIOWrapper
 import concurrent.futures as cf
-from datetime import datetime, UTC
+from datetime import datetime
 import gzip
 import tarfile, tempfile
 from forcingprocessor.weights_hf2ds import multiprocess_hf2ds
@@ -701,7 +701,7 @@ def prep_ngen_data(conf):
 
     t_start = time.perf_counter()
 
-    datentime = datetime.now(UTC).strftime("%m%d%y_%H%M%S")   
+    datentime = datetime.utcnow().strftime("%m%d%y_%H%M%S")   
 
     log_file = "./profile_fp.txt"   
     log_time("FORCINGPROCESSOR_START", log_file) 


### PR DESCRIPTION
Due to current issues with 3.12, rolling forcingprocessor back to 3.9 python.