### PR TITLE
Documentation updates

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,9 +1,1 @@
-```
-DATASTREAM_PATH="$(eval echo ~$USER)/ngen-datastream"
-DATASTREAM_DOCKER="$DATASTREAM_PATH"/docker
-
-cd $DATASTREAM_DOCKER
-docker build -t datastream-deps:latest -f Dockerfile.datastream-deps . --no-cache --build-arg TAG_NAME=latest && \
-docker build -t forcingprocessor:latest -f Dockerfile.forcingprocessor . --no-cache --build-arg TAG_NAME=latest && \
-    docker build -t validator:latest -f Dockerfile.validator . --no-cache --build-arg TAG_NAME=latest
-```
+See the [docker builds script README](https://github.com/CIROH-UA/ngen-datastream/tree/main/scripts/README.md#scripts/docker_builds.sh).

--- a/docs/DATASTREAM_OPTIONS.md
+++ b/docs/DATASTREAM_OPTIONS.md
@@ -27,9 +27,9 @@ or run with cli args
   ```
 
 ### Explanation of cli args (or variables in defined in `CONF_FILE`)
-| Field               | Flag | Description              | Required | STATUS  |
-|---------------------|------|--------------------|------|------|
-| START_DATE          | `-s` |Start simulation time (YYYYMMDDHHMM) or "DAILY" | :white_check_mark: | ![datastream options status](https://github.com/CIROH-UA/ngen-datastream/actions/workflows/test_datastream_options.yaml/badge.svg) |
+| Field               | Flag | Description              | Required   |
+|---------------------|------|--------------------|------|
+| START_DATE          | `-s` |Start simulation time (YYYYMMDDHHMM) or "DAILY" | :white_check_mark: | |
 | END_DATE            | `-e` |End simulation time  (YYYYMMDDHHMM) | :white_check_mark: |
 | FORCING_SOURCE | `-C` |Select the forcings data provider. Format is `NWM_$VERSION_$RUN_TYPE_$INIT_CYCLE_$MEMBER` Options include NWM_RETRO_V2, NWM_RETRO_V3, NWM_V3_SHORT_RANGE_00, NWM_V3_MEDIUM_RANGE_00_0, NWM_V3_ANALYSIS_ASSIM_16, NWM_V3_ANALYSIS_ASSIM_EXTEND, NOMADS, NOMADS_POSTPROCESSED | :white_check_mark: |
 | DATA_DIR           | `-d` |Absolute local path to construct the datastream run. | :white_check_mark: |
@@ -49,3 +49,21 @@ or run with cli args
 | NPROCS              | `-n` | Maximum number of processes to use in any step of  `ngen-datastream`. Defaults to `nprocs - 2` |  |
 | CONF_FILE            | `-c` | Store CLI args as env variables in a file. |  |
 | EVAL | `-E` | Set to "True" to run the TEEHR automated evaluation service on NextGen outputs. |  |
+
+### Note for supplying file(s) paths
+DataStreamCLI is designed to pick up files or folder whether they are local, public, or in AWS s3 object storage.
+
+DataStreamCLI can accept local or non-local paths. The following are all allowed.
+``` 
+For file like paths (i.e. providing explicit geopackage path)
+1. A local absolute (or relative) path : /home/user/data/nextgen_VPU_09.gpkg
+2. A URL : https://ciroh-community-ngen-datastream.s3.us-east-1.amazonaws.com/v2.2_resources/VPU_09/config/nextgen_VPU_09.gpkg
+3. A s3 URI: s3://ciroh-community-ngen-datastream/v2.2_resources/VPU_09/config/nextgen_VPU_09.gpkg
+
+For folder like paths (i.e. providing a resource directory)
+1. A local absolute (or relative) folder : /home/user/data/v2.2_resources/VPU_09
+2. A s3 URI prefix : s3://ciroh-community-ngen-datastream/v2.2_resources/VPU_09
+```
+
+Note here that DataStreamCLI will treat a s3 URI prefix like a directory.
+

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,82 @@
+# scripts/datastream_guide
+Run the guide script with
+```
+/scripts/datastream_guide
+```
+and an interactive program will run that will guide the user step-by-step to build a DataStreamCLI command. Each option is explained and there is an optional tour of the repository.
+
+# scripts/datastream
+This script is what is referred to as by DataStreamCLI. There are numerous ways to execute this script. See the [DataStreamCLI options docs](https://github.com/CIROH-UA/ngen-datastream/blob/main/docs/DATASTREAM_OPTIONS.md) for explainations of each cli arg. Some examples are provided below.
+
+### One-off execution examples
+1.
+    For a NOM, CFE, PET, troute NextGen execution over Palisade, Colorado on 20200620 using the National Water Model v3 retrospective forcings:
+    ```
+    ./scripts/datastream -s 202006200100 \
+                        -e 202006210000 \
+                        -C NWM_RETRO_V3 \
+                        -d ./data/datastream_test \
+                        -g https://ciroh-community-ngen-datastream.s3.us-east-1.amazonaws.com/v2.2_resources/VPU_09/config/nextgen_VPU_09.gpkg \
+                        -R ./configs/ngen/realization_sloth_nom_cfe_pet_troute.json \
+                        -n 4
+    ```
+    `-s` and `-e` set the start and end data. `-C` set the forcing source. `-d` sets the local output directory. `-g` sets the geopackage, which defines the spatial domain. `-R` sets the NextGen configuration file, also referred to as a realization file. `-n` sets the maximum number of processes to utilize during the DataStreamCLI execution.
+
+2.
+    To repeat example 1 over a different time period, the resource directroy and be reused in future executions over the same domain.
+
+    Copy the resource directory
+    ```
+    cp 
+    ```
+
+### NextGen Research DataStream releated examples:
+The backend software of the NextGen Research DataStream is DataStreamCLI. Several examples are given below to help illustrate the different ways DataStreamCLI can be executed. While the NextGen Research DataStream executions occur within AWS cloud, these commands will execute in a local environment. See the [NextGen Research DataStream docs](https://github.com/CIROH-UA/ngen-datastream/tree/main/research_datastream) for more information on the design.
+
+Daily short range for VPU 16 forecast cycle 12 on 20250730. 
+```
+/ngen-datastream/scripts/datastream \
+    -s DAILY \
+    -e 202507300000 \
+    -n 3 \
+    -F s3://ciroh-community-ngen-datastream/v2.2/ngen.20250730/forcing_short_range/12/ngen.t12z.short_range.forcing.f001_f018.VPU_16.nc \
+    -d /home/ec2-user/outputs \
+    -r s3://ciroh-community-ngen-datastream.s3.us-east-1.amazonaws.com/v2.2_resources/VPU_16 \
+    -R https://ciroh-community-ngen-datastream.s3.us-east-1.amazonaws.com/realizations/realization_VPU_16.json \
+    --FORCING_SOURCE NWM_V3_SHORT_RANGE_12 \
+    --S3_BUCKET ciroh-community-ngen-datastream \
+    --S3_PREFIX test/v2.2/ngen.20250730/short_range/12/VPU_16
+```
+
+Note the `-e` options sets the date . This is required whenever the user desires a "DAILY" run using forcing from a day other than today. Therefore, the production research datastream system does not actually set the `-e` option.
+
+Additionally, the NextGen Research DataStream executions riot set the following environment variables
+```
+export DS_TAG=1.0.1 NGIAB_TAG=v0.0.0
+```
+in order to override the default tag of "latest". 
+
+# scripts/docker_builds.sh
+This script handles the docker builds for the parent `datastream-deps` and the primary `datastream` and `forcingprocessor` docker containers. The script will build from the files locally, so it is easy for users to build their own variant containers and tag them readily. 
+
+For example.
+```
+scripts/docker_builds. -e -d -f -t my-local-containers-latest
+```
+
+will build the containers locally.
+
+```
+awiciroh/datastream-deps:my-local-containers-latest
+awiciroh/datastream:my-local-containers-latest
+awiciroh/forcingprocessor:my-local-containers-latest
+```
+
+Options
+```
+-e builds datastream-deps
+-d builds datastream
+-f builds forcingprocessor
+-p pushes containers to dockerhub (for admin use only)
+-t sets the tag
+```


### PR DESCRIPTION
This PR provides 
* examples for executing DataStreamCLI (`scripts/datastream`) in `scripts/README.md`
* DataStreamCLI options path notes at `docs/DATASTREAM_OPTIONS.md`
* documentation for the docker build script `scripts/docker_builds.sh` in `scripts/README.md`
* documentation for the DataStreamCLI guide `scripts/datastream_guide` in `scripts/README.md`
