### PR TITLE
issue_197

### DIFF
--- a/.github/workflows/build_ami.yml
+++ b/.github/workflows/build_ami.yml
@@ -1,0 +1,97 @@
+name: Build, Test, and Push Datastream AMI
+on:
+  workflow_dispatch:   
+  push:
+    branches: 
+      - main
+    paths:
+      - 'ami_version.yml'
+
+permissions:
+  contents: read   
+
+jobs:
+  build-test-push-docker-arm:
+    runs-on: ubuntu-latest
+    outputs:
+      ds_tag: ${{ steps.changes.outputs.ds_tag }}
+      fp_tag: ${{ steps.changes.outputs.fp_tag }}
+      ngiab_tag: ${{ steps.changes.outputs.ngiab_tag }}
+      ds_ami_version: ${{ steps.changes.outputs.ds_ami_version }}
+      build_ds_ami: ${{ steps.changes.outputs.build_ds_ami }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Install yq
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+
+      - name: Detect version changes
+        id: changes
+        shell: bash
+        run: |
+          set -euo pipefail
+      
+          # Current versions
+          CURRENT_DS_AMI=$(yq -r e '."datastream-ami-version"' ami_version.yml)
+          DS_TAG=$(yq -r e '.DS_TAG' ami_version.yml)
+          FP_TAG=$(yq -r e '.FP_TAG' ami_version.yml)
+          NGIAB_TAG=$(yq -r e '.NGIAB_TAG' ami_version.yml)
+      
+          # Ensure previous commit and file exist
+          if git rev-parse HEAD~1 >/dev/null 2>&1 && git cat-file -e HEAD~1:ami_version.yml 2>/dev/null; then
+            git show HEAD~1:ami_version.yml > previous_versions.yml
+          else
+            printf "datastream-ami-version: '0.0.0'\n" > previous_versions.yml
+          fi
+      
+          PREVIOUS_DS_AMI=$(yq -r e '."datastream-ami-version"' previous_versions.yml)
+      
+          # Outputs for AMI change detection
+          if [ "$CURRENT_DS_AMI" != "$PREVIOUS_DS_AMI" ]; then
+            echo "datastream-ami-version changed: $PREVIOUS_DS_AMI -> $CURRENT_DS_AMI"
+            echo "build_ds_ami=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "build_ds_ami=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "ds_ami_version=$CURRENT_DS_AMI" >> "$GITHUB_OUTPUT"
+
+          # Outputs for tags
+          echo "ds_tag=$DS_TAG" >> "$GITHUB_OUTPUT"
+          echo "fp_tag=$FP_TAG" >> "$GITHUB_OUTPUT"
+          echo "ngiab_tag=$NGIAB_TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Configure AWS
+        run: |
+          aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws configure set region us-east-1        
+
+
+      - name: Build AMI on AWS (N Virginia)
+        run: |
+          ami_version=""
+          DS_TAG="${{ steps.changes.outputs.ds_tag }}"
+          FP_TAG="${{ steps.changes.outputs.fp_tag }}"
+          NGIAB_TAG="${{ steps.changes.outputs.ngiab_tag }}"
+          
+          if [ "${{ steps.changes.outputs.build_ds_ami }}" == "true" ]; then
+            ami_version=datastream-"${{ steps.changes.outputs.ds_ami_version }}"
+          fi
+          
+          # Update AMI name
+          sed -i "s|AMI_NAME=\"ami_tag\"|AMI_NAME=\"$ami_version\"|" scripts/create_ami.sh
+          
+          # Update the workflow tag placeholders with actual values
+          sed -i "s|ds_tag_from_workflow|$DS_TAG|g" scripts/create_ami.sh
+          sed -i "s|fp_tag_from_workflow|$FP_TAG|g" scripts/create_ami.sh
+          sed -i "s|ngiab_tag_from_workflow|$NGIAB_TAG|g" scripts/create_ami.sh
+          
+          cat scripts/create_ami.sh
+          chmod +x scripts/create_ami.sh
+          ./scripts/create_ami.sh

--- a/ami_version.yml
+++ b/ami_version.yml
@@ -1,0 +1,4 @@
+datastream-ami-version: "1.6.7"
+DS_TAG: "1.0.1"
+FP_TAG: "latest"
+NGIAB_TAG: "latest"

--- a/scripts/create_ami.sh
+++ b/scripts/create_ami.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+set -e
+# Configuration
+REGION="us-east-1"
+INSTANCE_TYPE="t4g.large"
+# Get the latest Amazon Linux 2023 ARM64 AMI ID dynamically
+BASE_AMI=$(aws ssm get-parameter --name /aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-arm64 --region "$REGION" --query "Parameter.Value" --output text)
+KEY_NAME="actions_key_arm"
+SECURITY_GROUP="sg-0fcbe0c6d6faa0117"
+AMI_NAME="ami_tag"
+echo "Creating AMI with key pair: $KEY_NAME and security group: $SECURITY_GROUP" >&2
+echo "Using base AMI: $BASE_AMI" >&2
+USER_DATA='#!/bin/bash
+exec > >(tee /var/log/user-data.log)
+exec 2>&1
+echo "Updating system packages..."
+dnf update -y
+echo "Installing git..."
+dnf install -y git
+dnf install -y docker
+dnf install -y python3-pip pigz awscli tar wget
+echo "Starting Docker service..."
+systemctl start docker
+systemctl enable docker
+usermod -aG docker ec2-user
+echo "Waiting for Docker to be ready..."
+sleep 10
+echo "Installing hfsubset..."
+cd /tmp
+curl -L -O https://github.com/lynker-spatial/hfsubsetCLI/releases/download/v1.1.0/hfsubset-v1.1.0-linux_arm64.tar.gz
+tar -xzvf hfsubset-v1.1.0-linux_arm64.tar.gz
+mv ./hfsubset /usr/bin/hfsubset
+chmod +x /usr/bin/hfsubset
+echo "Cloning ngen-datastream repository..."
+cd /home/ec2-user
+sudo -u ec2-user git clone https://github.com/CIROH-UA/ngen-datastream.git
+chown -R ec2-user:ec2-user /home/ec2-user/ngen-datastream
+echo "Updating datastream script with placeholder tags..."
+sed -i '\''s|DS_TAG=${DS_TAG:-"latest"}|DS_TAG=${DS_TAG:-"ds_tag_from_workflow"}|'\'' /home/ec2-user/ngen-datastream/scripts/datastream
+sed -i '\''s|FP_TAG=${FP_TAG:-"latest"}|FP_TAG=${FP_TAG:-"fp_tag_from_workflow"}|'\'' /home/ec2-user/ngen-datastream/scripts/datastream
+sed -i '\''s|NGIAB_TAG=${NGIAB_TAG:-"latest"}|NGIAB_TAG=${NGIAB_TAG:-"ngiab_tag_from_workflow"}|'\'' /home/ec2-user/ngen-datastream/scripts/datastream
+grep -E "(DS_TAG|FP_TAG|NGIAB_TAG)" /home/ec2-user/ngen-datastream/scripts/datastream
+echo "=== Setup completed successfully at $(date) ===" > /var/log/setup-complete
+echo "Setup completed successfully!"
+'
+# Launch instance
+INSTANCE_ID=$(aws ec2 run-instances \
+    --region "$REGION" \
+    --image-id "$BASE_AMI" \
+    --instance-type "$INSTANCE_TYPE" \
+    --key-name "$KEY_NAME" \
+    --security-group-ids "$SECURITY_GROUP" \
+    --user-data "$USER_DATA" \
+    --block-device-mappings '[{"DeviceName":"/dev/xvda","Ebs":{"VolumeSize":32,"VolumeType":"gp3"}}]' \
+    --query 'Instances[0].InstanceId' \
+    --output text)
+# Wait for running and setup
+aws ec2 wait instance-running --region "$REGION" --instance-ids "$INSTANCE_ID"
+sleep 900  # 15 minutes for setup
+# Stop instance
+aws ec2 stop-instances --region "$REGION" --instance-ids "$INSTANCE_ID" >/dev/null
+aws ec2 wait instance-stopped --region "$REGION" --instance-ids "$INSTANCE_ID"
+# Create AMI
+AMI_ID=$(aws ec2 create-image \
+    --region "$REGION" \
+    --instance-id "$INSTANCE_ID" \
+    --name "$AMI_NAME" \
+    --description "ngen-datastream AMI" \
+    --query 'ImageId' \
+    --output text)
+# Wait for AMI
+aws ec2 wait image-available --region "$REGION" --image-ids "$AMI_ID"
+# Cleanup
+aws ec2 terminate-instances --region "$REGION" --instance-ids "$INSTANCE_ID" >/dev/null
+# Output only the AMI ID
+echo "$AMI_ID"


### PR DESCRIPTION
This PR adds an automated, version-aware pipeline to build and publish a Datastream ARM64 AMI whenever ami_version.yml is updated. The GitHub Actions workflow detects version or tag changes in this file, injects them into create_ami.sh, and provisions an Amazon Linux 2023 ARM64 instance in us-east-1. The instance is bootstrapped with required dependencies, the ngen-datastream repository is cloned, and default container tags for Datastream, ForcingProcessor, and NGIAB are replaced with the values from the workflow before baking the AMI.

The resulting AMI is named datastream-<version> and includes the updated container tags baked in for reproducibility and consistency across environments. This process ensures that each new AMI is built only when needed, keeps version management centralized in ami_version.yml, and reduces manual intervention while maintaining traceability of the versions used in the image.