### PR TITLE
updated workflow and createami.sh

### DIFF
--- a/.github/workflows/build_test_create_ami.yml
+++ b/.github/workflows/build_test_create_ami.yml
@@ -72,7 +72,6 @@ jobs:
           aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws configure set region us-east-1        
 
-
       - name: Build AMI on AWS (N Virginia)
         if: steps.changes.outputs.build_ds_ami == 'true'
         run: |
@@ -85,17 +84,14 @@ jobs:
             ami_version=datastream-"${{ steps.changes.outputs.ds_ami_version }}"
           fi
           
-          # Update AMI name
-          sed -i "s|AMI_NAME=\"ami_tag\"|AMI_NAME=\"$ami_version\"|" scripts/create_ami.sh
-          
-          # Update the workflow tag placeholders with actual values
-          sed -i "s|ds_tag_from_workflow|$DS_TAG|g" scripts/create_ami.sh
-          sed -i "s|fp_tag_from_workflow|$FP_TAG|g" scripts/create_ami.sh
-          sed -i "s|ngiab_tag_from_workflow|$NGIAB_TAG|g" scripts/create_ami.sh
-          cat scripts/create_ami.sh
+          # Pass environment variables to the script
+          export AMI_NAME="$ami_version"
+          export DS_TAG="$DS_TAG"
+          export FP_TAG="$FP_TAG"
+          export NGIAB_TAG="$NGIAB_TAG"
           chmod +x scripts/create_ami.sh
           ./scripts/create_ami.sh
-
+          
   get-ami-info:
     needs: build-test-push-ami
     if: needs.build-test-push-ami.outputs.build_ds_ami == 'true'
@@ -174,11 +170,13 @@ jobs:
           # Download the proven working execution JSON from S3
           aws s3 cp s3://ciroh-community-ngen-datastream/v2.2/ngen.${{ env.DATE }}/forcing_short_range/00/metadata/execution.json execution.json
           
-          # Replace the working AMI with your custom one
-          sed -i "s|ami-0e621409bdbd530a0|$ami_id|g" execution.json
+          # Replace the working AMI with custom one
+          jq --arg ami "$ami_id" '.instance_parameters.ImageId = $ami' execution.json > execution_updated.json
+          mv execution_updated.json execution.json
+          echo $ami_id
           # Replace Docker image tags with specific versions
-          sed -i "s|awiciroh/datastream:latest|awiciroh/datastream:${{ needs.build-test-push-ami.outputs.ds_tag }}|g" execution.json
-          sed -i "s|awiciroh/forcingprocessor:latest|awiciroh/forcingprocessor:${{ needs.build-test-push-ami.outputs.fp_tag }}|g" execution.json
+          sed -i "s|DS_TAG=1.0.1|DS_TAG=${{ needs.build-test-push-ami.outputs.ds_tag }}|g" execution.json
+          sed -i "s|NGIAB_TAG=v0.0.0|NGIAB_TAG=${{ needs.build-test-push-ami.outputs.ngiab_tag }}|g" execution.json
           cat execution.json
           # Show key info (avoid dumping entire JSON to logs)
           echo "AMI replacement completed for VPU ${{ env.VPU }}"
@@ -319,11 +317,15 @@ jobs:
           # Download the proven working execution JSON from S3
           aws s3 cp s3://ciroh-community-ngen-datastream/v2.2/ngen.${{ env.DATE }}/short_range/00/VPU_16/datastream-metadata/execution.json execution.json
           
-          # Replace the working AMI with your custom one
-          sed -i "s|ami-0e621409bdbd530a0|$ami_id|g" execution.json
+          # Replace the working AMI with custom one
+          jq --arg ami "$ami_id" '.instance_parameters.ImageId = $ami' execution.json > execution_updated.json
+          mv execution_updated.json execution.json
+          echo $ami_id
           # Replace Docker image tags with specific versions
-          sed -i "s|awiciroh/datastream:latest|awiciroh/datastream:${{ needs.build-test-push-ami.outputs.ds_tag }}|g" execution.json
-          sed -i "s|awiciroh/forcingprocessor:latest|awiciroh/forcingprocessor:${{ needs.build-test-push-ami.outputs.fp_tag }}|g" execution.json
+          sed -i "s|DS_TAG=1.0.1|DS_TAG=${{ needs.build-test-push-ami.outputs.ds_tag }}|g" execution.json
+          sed -i "s|NGIAB_TAG=v0.0.0|NGIAB_TAG=${{ needs.build-test-push-ami.outputs.ngiab_tag }}|g" execution.json
+          cat execution.json
+
           # Show key info (avoid dumping entire JSON to logs)
           echo "AMI replacement completed for VPU ${{ env.VPU }}"
           echo "New AMI ID: $(jq -r '.instance_parameters.ImageId' execution.json)"

--- a/scripts/create_ami.sh
+++ b/scripts/create_ami.sh
@@ -1,76 +1,163 @@
 #!/bin/bash
 set -e
+
 # Configuration
 REGION="us-east-1"
 INSTANCE_TYPE="t4g.large"
+
 # Get the latest Amazon Linux 2023 ARM64 AMI ID dynamically
 BASE_AMI=$(aws ssm get-parameter --name /aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-arm64 --region "$REGION" --query "Parameter.Value" --output text)
+
 KEY_NAME="actions_key_arm"
 SECURITY_GROUP="sg-0fcbe0c6d6faa0117"
-AMI_NAME="ami_tag"
+
+# Use environment variables passed from workflow (with defaults)
+AMI_NAME="${AMI_NAME:-ami_tag}"
+DS_TAG="${DS_TAG:-latest}"
+FP_TAG="${FP_TAG:-latest}"
+NGIAB_TAG="${NGIAB_TAG:-latest}"
+
 echo "Creating AMI with key pair: $KEY_NAME and security group: $SECURITY_GROUP" >&2
 echo "Using base AMI: $BASE_AMI" >&2
-USER_DATA='#!/bin/bash
+echo "AMI Name: $AMI_NAME" >&2
+echo "Tags: DS_TAG=$DS_TAG, FP_TAG=$FP_TAG, NGIAB_TAG=$NGIAB_TAG" >&2
+
+# Create user data script using a here document for better formatting
+cat > /tmp/user_data_script.sh << 'USER_DATA_EOF'
+#!/bin/bash
 exec > >(tee /var/log/user-data.log)
 exec 2>&1
+
+echo "Starting user data execution at $(date)"
+
+# Set the actual tag values from workflow
+USER_DATA_EOF
+
+# Add the environment variables to the script
+cat >> /tmp/user_data_script.sh << USER_DATA_VARS
+export DS_TAG='$DS_TAG'
+export FP_TAG='$FP_TAG'
+export NGIAB_TAG='$NGIAB_TAG'
+
+echo "Starting setup with tags: DS_TAG=\$DS_TAG, FP_TAG=\$FP_TAG, NGIAB_TAG=\$NGIAB_TAG"
+
+USER_DATA_VARS
+
+# Add the rest of the setup script
+cat >> /tmp/user_data_script.sh << 'USER_DATA_SETUP'
 echo "Updating system packages..."
 dnf update -y
+
 echo "Installing git..."
 dnf install -y git
 dnf install -y docker
 dnf install -y python3-pip pigz awscli tar wget
+
 echo "Starting Docker service..."
 systemctl start docker
 systemctl enable docker
 usermod -aG docker ec2-user
+
 echo "Waiting for Docker to be ready..."
 sleep 10
+
 echo "Installing hfsubset..."
 cd /tmp
 curl -L -O https://github.com/lynker-spatial/hfsubsetCLI/releases/download/v1.1.0/hfsubset-v1.1.0-linux_arm64.tar.gz
 tar -xzvf hfsubset-v1.1.0-linux_arm64.tar.gz
 mv ./hfsubset /usr/bin/hfsubset
 chmod +x /usr/bin/hfsubset
+
 echo "Cloning ngen-datastream repository..."
 cd /home/ec2-user
 sudo -u ec2-user git clone https://github.com/CIROH-UA/ngen-datastream.git
 chown -R ec2-user:ec2-user /home/ec2-user/ngen-datastream
-echo "Updating datastream script with placeholder tags..."
-sed -i '\''s|DS_TAG=${DS_TAG:-"latest"}|DS_TAG=${DS_TAG:-"ds_tag_from_workflow"}|'\'' /home/ec2-user/ngen-datastream/scripts/datastream
-sed -i '\''s|FP_TAG=${FP_TAG:-"latest"}|FP_TAG=${FP_TAG:-"fp_tag_from_workflow"}|'\'' /home/ec2-user/ngen-datastream/scripts/datastream
-sed -i '\''s|NGIAB_TAG=${NGIAB_TAG:-"latest"}|NGIAB_TAG=${NGIAB_TAG:-"ngiab_tag_from_workflow"}|'\'' /home/ec2-user/ngen-datastream/scripts/datastream
-grep -E "(DS_TAG|FP_TAG|NGIAB_TAG)" /home/ec2-user/ngen-datastream/scripts/datastream
+
+echo "Checking if datastream script exists..."
+if [ -f "/home/ec2-user/ngen-datastream/scripts/datastream" ]; then
+    echo "Found datastream script, updating with actual tag values..."
+    
+    # Show original content
+    echo "Original tag definitions:"
+    grep -E "(DS_TAG|FP_TAG|NGIAB_TAG)" /home/ec2-user/ngen-datastream/scripts/datastream || echo "No tag definitions found"
+    
+    # Update the tags
+    sed -i "s|DS_TAG=\${DS_TAG:-\"latest\"}|DS_TAG=\${DS_TAG:-\"$DS_TAG\"}|" /home/ec2-user/ngen-datastream/scripts/datastream
+    sed -i "s|FP_TAG=\${FP_TAG:-\"latest\"}|FP_TAG=\${FP_TAG:-\"$FP_TAG\"}|" /home/ec2-user/ngen-datastream/scripts/datastream
+    sed -i "s|NGIAB_TAG=\${NGIAB_TAG:-\"latest\"}|NGIAB_TAG=\${NGIAB_TAG:-\"$NGIAB_TAG\"}|" /home/ec2-user/ngen-datastream/scripts/datastream
+    
+    echo "Updated tag definitions:"
+    grep -E "(DS_TAG|FP_TAG|NGIAB_TAG)" /home/ec2-user/ngen-datastream/scripts/datastream || echo "No tag definitions found after update"
+else
+    echo "ERROR: datastream script not found at expected location!"
+    echo "Checking repository structure..."
+    find /home/ec2-user/ngen-datastream -name "*datastream*" -type f || echo "No datastream files found"
+    echo "Repository contents:"
+    ls -la /home/ec2-user/ngen-datastream/
+    if [ -d "/home/ec2-user/ngen-datastream/scripts" ]; then
+        echo "Scripts directory contents:"
+        ls -la /home/ec2-user/ngen-datastream/scripts/
+    else
+        echo "Scripts directory does not exist"
+    fi
+fi
+
 echo "=== Setup completed successfully at $(date) ===" > /var/log/setup-complete
 echo "Setup completed successfully!"
-'
+USER_DATA_SETUP
+
+# Read the complete user data script
+USER_DATA=$(cat /tmp/user_data_script.sh)
+
 # Launch instance
+echo "Launching EC2 instance..."
 INSTANCE_ID=$(aws ec2 run-instances \
     --region "$REGION" \
     --image-id "$BASE_AMI" \
     --instance-type "$INSTANCE_TYPE" \
     --key-name "$KEY_NAME" \
     --security-group-ids "$SECURITY_GROUP" \
-    --user-data "$USER_DATA" \
+    --user-data file:///tmp/user_data_script.sh \
     --block-device-mappings '[{"DeviceName":"/dev/xvda","Ebs":{"VolumeSize":32,"VolumeType":"gp3"}}]' \
     --query 'Instances[0].InstanceId' \
     --output text)
+
+echo "Instance ID: $INSTANCE_ID"
+
 # Wait for running and setup
+echo "Waiting for instance to be running..."
 aws ec2 wait instance-running --region "$REGION" --instance-ids "$INSTANCE_ID"
-sleep 900  # 15 minutes for setup
+
+echo "Waiting 6 minutes for setup to complete..."
+sleep 400  # 6 minutes for setup
+
 # Stop instance
+echo "Stopping instance..."
 aws ec2 stop-instances --region "$REGION" --instance-ids "$INSTANCE_ID" >/dev/null
 aws ec2 wait instance-stopped --region "$REGION" --instance-ids "$INSTANCE_ID"
+
 # Create AMI
+echo "Creating AMI: $AMI_NAME"
 AMI_ID=$(aws ec2 create-image \
     --region "$REGION" \
     --instance-id "$INSTANCE_ID" \
     --name "$AMI_NAME" \
-    --description "ngen-datastream AMI" \
+    --description "ngen-datastream AMI with DS_TAG=$DS_TAG, FP_TAG=$FP_TAG, NGIAB_TAG=$NGIAB_TAG" \
     --query 'ImageId' \
     --output text)
+
+echo "AMI ID: $AMI_ID"
+
 # Wait for AMI
+echo "Waiting for AMI to be available..."
 aws ec2 wait image-available --region "$REGION" --image-ids "$AMI_ID"
+
 # Cleanup
+echo "Terminating instance..."
 aws ec2 terminate-instances --region "$REGION" --instance-ids "$INSTANCE_ID" >/dev/null
+
+# Clean up temporary file
+rm -f /tmp/user_data_script.sh
+
 # Output only the AMI ID
 echo "$AMI_ID"


### PR DESCRIPTION
create_ami.sh:-

Switched from inline USER_DATA string → here-doc script (/tmp/user_data_script.sh) for clarity and maintainability.
Replaced sed placeholder substitutions with environment variables (AMI_NAME, DS_TAG, FP_TAG, NGIAB_TAG) passed from workflow.
Added existence check for datastream script and logging of tag values before/after updates.

Improved logging:
Show AMI name, tags, instance ID, setup start/end times.


Reduced setup wait time:
- sleep 900   # 15 minutes
+ sleep 400   # ~6.5 minutes


AMI description now includes tag values:
- "ngen-datastream AMI"
+ "ngen-datastream AMI with DS_TAG=..., FP_TAG=..., NGIAB_TAG=..."

AMI Build Step
Before: Used sed to patch values in create_ami.sh.
After: Export env vars → consumed directly by create_ami.sh.

- sed -i "s|ds_tag_from_workflow|$DS_TAG|g" scripts/create_ami.sh
- sed -i "s|fp_tag_from_workflow|$FP_TAG|g" scripts/create_ami.sh
- sed -i "s|ngiab_tag_from_workflow|$NGIAB_TAG|g" scripts/create_ami.sh
+ export AMI_NAME="$ami_version"
+ export DS_TAG="$DS_TAG"
+ export FP_TAG="$FP_TAG"
+ export NGIAB_TAG="$NGIAB_TAG"


Execution JSON updates:-
  Injects AMI ID via jq instead of sed.
  More explicit tag replacements:
    - sed -i "s|awiciroh/datastream:latest|awiciroh/datastream:${{ ... }}|g"
    - sed -i "s|awiciroh/forcingprocessor:latest|awiciroh/forcingprocessor:${{ ... }}|g"
    + sed -i "s|DS_TAG=1.0.1|DS_TAG=${{ ... }}|g"
    + sed -i "s|NGIAB_TAG=v0.0.0|NGIAB_TAG=${{ ... }}|g"


Added debug output: prints AMI ID and updated JSON contents.

Net Result:
  Cleaner, safer, and more traceable AMI build pipeline.
  Easier debugging and maintenance.
  Reduced build times by ~9 minutes.