### PR TITLE
Version-Aware Docker Build and Push Workflow with Tagging

### DIFF
--- a/.github/workflows/build_test_push_docker_X86_arm_version_aware
+++ b/.github/workflows/build_test_push_docker_X86_arm_version_aware
@@ -1,0 +1,271 @@
+name: Build, Test, and Push Datastream Docker Containers on X86 and ARM (Version Aware)
+
+on:
+  workflow_dispatch:   
+  push:
+    branches:
+      - release_tags
+    paths:
+      - 'versions.yml'
+
+permissions:
+  contents: read   
+
+jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      build_deps: ${{ steps.changes.outputs.build_deps }}
+      build_fp: ${{ steps.changes.outputs.build_fp }}
+      build_ds: ${{ steps.changes.outputs.build_ds }}
+      deps_version: ${{ steps.changes.outputs.deps_version }}
+      fp_version: ${{ steps.changes.outputs.fp_version }}
+      ds_version: ${{ steps.changes.outputs.ds_version }}
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 2
+
+    - name: Install yq
+      run: |
+        sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+        sudo chmod +x /usr/local/bin/yq
+
+    - name: Detect version changes
+      id: changes
+      shell: bash
+      run: |
+        set -euo pipefail
+    
+        # Current versions (raw)
+        CURRENT_DEPS=$(yq -r e '."datastream-deps"' versions.yml)
+        CURRENT_FP=$(yq -r e '.forcingprocessor' versions.yml)
+        CURRENT_DS=$(yq -r e '.datastream' versions.yml)
+    
+        # Ensure previous commit and file exist
+        if git rev-parse HEAD~1 >/dev/null 2>&1 && git cat-file -e HEAD~1:versions.yml 2>/dev/null; then
+          git show HEAD~1:versions.yml > previous_versions.yml
+        else
+          printf "datastream-deps: '0.0.0'\nforcingprocessor: '0.0.0'\ndatastream: '0.0.0'\n" > previous_versions.yml
+        fi
+    
+        PREVIOUS_DEPS=$(yq -r e '."datastream-deps"' previous_versions.yml)
+        PREVIOUS_FP=$(yq -r e '.forcingprocessor' previous_versions.yml)
+        PREVIOUS_DS=$(yq -r e '.datastream' previous_versions.yml)
+    
+        # Check what changed and set outputs
+        if [ "$CURRENT_DEPS" != "$PREVIOUS_DEPS" ]; then
+          echo "datastream-deps changed: $PREVIOUS_DEPS -> $CURRENT_DEPS"
+          echo "build_deps=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "build_deps=false" >> "$GITHUB_OUTPUT"
+        fi
+        echo "deps_version=$CURRENT_DEPS" >> "$GITHUB_OUTPUT"
+    
+        if [ "$CURRENT_FP" != "$PREVIOUS_FP" ]; then
+          echo "forcingprocessor changed: $PREVIOUS_FP -> $CURRENT_FP"
+          echo "build_fp=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "build_fp=false" >> "$GITHUB_OUTPUT"
+        fi
+        echo "fp_version=$CURRENT_FP" >> "$GITHUB_OUTPUT"
+    
+        if [ "$CURRENT_DS" != "$PREVIOUS_DS" ]; then
+          echo "datastream changed: $PREVIOUS_DS -> $CURRENT_DS"
+          echo "build_ds=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "build_ds=false" >> "$GITHUB_OUTPUT"
+        fi
+        echo "ds_version=$CURRENT_DS" >> "$GITHUB_OUTPUT"
+
+  build-test-docker-x86:
+    needs: [detect-changes]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Configure AWS
+      run: |
+        aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws configure set region us-east-1
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Install packages for datastream
+      run: |
+        curl -L -O https://github.com/lynker-spatial/hfsubsetCLI/releases/download/v1.1.0/hfsubset-v1.1.0-linux_amd64.tar.gz && tar -xzvf hfsubset-v1.1.0-linux_amd64.tar.gz && sudo mv ./hfsubset /usr/bin/hfsubset && sudo apt-get update && sudo apt-get install git pip pigz -y        
+
+    - name: Build docker containers
+      run: |
+        chmod +x ./scripts/docker_builds.sh
+        ./scripts/docker_builds.sh -e -f -d -t latest-x86
+
+    - name: Prepare and test docker containers
+      run: |
+        curl -L -O https://ngen-datastream.s3.us-east-2.amazonaws.com/palisade.gpkg
+        export DS_TAG=latest-x86 FP_TAG=latest-x86 && ./scripts/datastream -s 202006200100 -e 202006200200 -C NWM_RETRO_V3 -d $(pwd)/data/datastream_test -g $(pwd)/palisade.gpkg -R $(pwd)/configs/ngen/realization_sloth_nom_cfe_pet.json -n 4
+
+    - name: Push docker containers
+      run: |
+        if [ "${{ needs.detect-changes.outputs.build_deps }}" == "true" ]; then
+          VERSION_TAG="${{ needs.detect-changes.outputs.deps_version }}"
+          docker tag awiciroh/datastream-deps:latest-x86 awiciroh/datastream-deps:${VERSION_TAG}-x86
+          docker push awiciroh/datastream-deps:${VERSION_TAG}-x86
+          docker push awiciroh/datastream-deps:latest-x86
+        fi
+        if [ "${{ needs.detect-changes.outputs.build_fp }}" == "true" ]; then
+          VERSION_TAG="${{ needs.detect-changes.outputs.fp_version }}"
+          docker tag awiciroh/forcingprocessor:latest-x86 awiciroh/forcingprocessor:${VERSION_TAG}-x86
+          docker push awiciroh/forcingprocessor:${VERSION_TAG}-x86
+          docker push awiciroh/forcingprocessor:latest-x86
+        fi
+        if [ "${{ needs.detect-changes.outputs.build_ds }}" == "true" ]; then
+          VERSION_TAG="${{ needs.detect-changes.outputs.ds_version }}"
+          docker tag awiciroh/datastream:latest-x86 awiciroh/datastream:${VERSION_TAG}-x86
+          docker push awiciroh/datastream:${VERSION_TAG}-x86
+          docker push awiciroh/datastream:latest-x86
+        fi
+
+  build-test-push-docker-arm:
+    needs: [detect-changes, build-test-docker-x86]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2
+        
+      - name: Configure AWS
+        run: |
+          aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws configure set region us-east-1
+          
+      - name: Build AWS Infra
+        run: |
+          cd research_datastream/terraform
+          terraform init
+          terraform validate
+          ../scripts/import_resources.sh ./test/variables_gitactions_arm.tfvars
+          terraform apply -var-file=./test/variables_gitactions_arm.tfvars -auto-approve
+          sleep 60
+          
+      - name: Set permissions
+        run: |
+          cd research_datastream/terraform
+          aws iam attach-role-policy --role-name datastream_ec2_role_github_actions_arm --policy-arn arn:aws:iam::aws:policy/SecretsManagerReadWrite
+          aws secretsmanager put-resource-policy --secret-id docker_awiciroh_creds --resource-policy file://test/secret-policy.json --block-public-policy --region us-east-1
+          if ! aws ec2 describe-key-pairs --key-names "actions_key_arm" --query 'KeyPairs[0].KeyName' --output text 2>/dev/null; then aws ec2 create-key-pair --key-name "actions_key_arm" --query 'KeyName' --output text && echo "Key pair 'actions_key_arm' created in AWS"; else echo "Key pair 'actions_key_arm' already exists"; fi
+          sleep 60
+          
+      - name: Build and Test arm docker containers with AWS infra
+        run: |
+          BUILD_FLAGS=""
+          TAG=""
+          
+          # Build flags and determine the most recent version for TAG
+          if [ "${{ needs.detect-changes.outputs.build_deps }}" == "true" ]; then
+            BUILD_FLAGS="$BUILD_FLAGS -e"
+            TAG="${{ needs.detect-changes.outputs.deps_version }}-arm64"
+          fi
+          if [ "${{ needs.detect-changes.outputs.build_fp }}" == "true" ]; then
+            BUILD_FLAGS="$BUILD_FLAGS -f"
+            TAG="${{ needs.detect-changes.outputs.fp_version }}-arm64"
+          fi
+          if [ "${{ needs.detect-changes.outputs.build_ds }}" == "true" ]; then
+            BUILD_FLAGS="$BUILD_FLAGS -d"
+            TAG="${{ needs.detect-changes.outputs.ds_version }}-arm64"
+          fi
+
+          if [ -z "$BUILD_FLAGS" ]; then
+            echo "No components changed, skipping ARM build"
+            exit 0
+          fi
+          
+          if [ -z "$TAG" ]; then
+            TAG="latest-arm64"  # fallback
+          fi
+          
+          BUILD_FLAGS=$(echo "$BUILD_FLAGS" | sed 's/^ *//')  
+          
+          cd research_datastream/terraform
+          sed -e "s/\${TAG}/$TAG/g" -e "s/\${BUILD_ARGS}/$BUILD_FLAGS/g" \
+              test/execution_gp_arm_docker_buildNtester.json > test/execution_temp.json
+          
+          echo "Generated execution file:"
+          cat test/execution_temp.json
+          
+          echo "Building with TAG: $TAG and FLAGS: $BUILD_FLAGS"
+          execution_arn=$(aws stepfunctions start-execution --state-machine-arn $(cat ./sm_ARN.txt) --name docker_builder_$(env TZ=US/Eastern date +'%Y%m%d%H%M%S') --input "file://test/execution_temp.json" --region us-east-1 --query 'executionArn' --output text); echo "Execution ARN: $execution_arn"; status="RUNNING"; while [ "$status" != "SUCCEEDED" ]; do status=$(aws stepfunctions describe-execution --execution-arn "$execution_arn" --region us-east-1 --query 'status' --output text); echo "Current status: $status"; if [ "$status" == "FAILED" ]; then echo "State machine execution failed!"; exit 1; fi; sleep 5; done; echo "State machine execution succeeded!"
+
+
+      - name: Tear down infra
+        if: always()
+        run: |
+          cd research_datastream/terraform
+          terraform destroy -var-file=./test/variables_gitactions_arm.tfvars -auto-approve
+          sleep 30
+
+  create-manifest:
+    name: Create and Push Manifest
+    needs: [detect-changes, build-test-push-docker-arm]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Create and push manifest datastream-deps
+        if: needs.detect-changes.outputs.build_deps == 'true'
+        run: |
+          docker manifest create awiciroh/datastream-deps:${{ needs.detect-changes.outputs.deps_version }} \
+            --amend awiciroh/datastream-deps:${{ needs.detect-changes.outputs.deps_version }}-x86 \
+            --amend awiciroh/datastream-deps:${{ needs.detect-changes.outputs.deps_version }}-arm64
+          docker manifest push awiciroh/datastream-deps:${{ needs.detect-changes.outputs.deps_version }}
+
+          docker manifest create awiciroh/datastream-deps:latest \
+            --amend awiciroh/datastream-deps:latest-x86 \
+            --amend awiciroh/datastream-deps:latest-arm64
+          docker manifest push awiciroh/datastream-deps:latest
+
+      - name: Create and push manifest datastream
+        if: needs.detect-changes.outputs.build_ds == 'true'
+        run: |
+          docker manifest create awiciroh/datastream:${{ needs.detect-changes.outputs.ds_version }} \
+            --amend awiciroh/datastream:${{ needs.detect-changes.outputs.ds_version }}-x86 \
+            --amend awiciroh/datastream:${{ needs.detect-changes.outputs.ds_version }}-arm64
+          docker manifest push awiciroh/datastream:${{ needs.detect-changes.outputs.ds_version }}
+
+          docker manifest create awiciroh/datastream:latest \
+            --amend awiciroh/datastream:latest-x86 \
+            --amend awiciroh/datastream:latest-arm64
+          docker manifest push awiciroh/datastream:latest       
+
+      - name: Create and push manifest forcingprocessor
+        if: needs.detect-changes.outputs.build_fp == 'true'
+        run: |
+          docker manifest create awiciroh/forcingprocessor:${{ needs.detect-changes.outputs.fp_version }} \
+            --amend awiciroh/forcingprocessor:${{ needs.detect-changes.outputs.fp_version }}-x86 \
+            --amend awiciroh/forcingprocessor:${{ needs.detect-changes.outputs.fp_version }}-arm64
+          docker manifest push awiciroh/forcingprocessor:${{ needs.detect-changes.outputs.fp_version }}
+
+          docker manifest create awiciroh/forcingprocessor:latest \
+            --amend awiciroh/forcingprocessor:latest-x86 \
+            --amend awiciroh/forcingprocessor:latest-arm64
+          docker manifest push awiciroh/forcingprocessor:latest

--- a/research_datastream/terraform/test/docker_loginNpush.sh
+++ b/research_datastream/terraform/test/docker_loginNpush.sh
@@ -1,14 +1,77 @@
 #!/bin/bash
 
+# Accept tag as command line argument, default to "latest-arm64" if not provided
+TAG="${1:-latest-arm64}"
+BUILD_ARGS="${2:-}"
+
+echo "Script called with TAG: $TAG, BUILD_ARGS: $BUILD_ARGS"
+
 DOCKERHUB_TOKEN="$(aws secretsmanager get-secret-value --secret-id docker_awiciroh_creds --region us-east-1 --query SecretString --output text | jq -r .DOCKERHUB_TOKEN)"
 DOCKERHUB_USERNAME="awiciroh"
 
-if [ "$(echo $DOCKERHUB_TOKEN | docker login -u $DOCKERHUB_USERNAME --password-stdin)" == "Login Succeeded" ]; then             
+# Parse BUILD_ARGS to determine what to push
+PUSH_DEPS="no"
+PUSH_FP="no"
+PUSH_DS="no"
+
+if [ -n "$BUILD_ARGS" ]; then
+    # Clean up BUILD_ARGS (remove quotes if present)
+    BUILD_ARGS_CLEAN=$(echo "$BUILD_ARGS" | sed 's/^"//;s/"$//')
+    echo "Processing build arguments: $BUILD_ARGS_CLEAN"
+    
+    # Check what services to push based on build flags
+    if [[ "$BUILD_ARGS_CLEAN" == *"-e"* ]]; then
+        PUSH_DEPS="yes"
+        echo "Will push datastream-deps"
+    fi
+    
+    if [[ "$BUILD_ARGS_CLEAN" == *"-f"* ]]; then
+        PUSH_FP="yes"
+        echo "Will push forcingprocessor"
+    fi
+    
+    if [[ "$BUILD_ARGS_CLEAN" == *"-d"* ]]; then
+        PUSH_DS="yes"
+        echo "Will push datastream"
+    fi
+else
+    echo "No BUILD_ARGS provided - nothing to push"
+    exit 0
+fi
+
+if echo "$DOCKERHUB_TOKEN" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin; then             
     echo "Docker login successful"
-    /home/ec2-user/ngen-datastream/scripts/docker_builds.sh -p -t latest-arm64 >> /home/ec2-user/ngen-datastream/docker_build_log.txt
-    echo "Push complete"
+    docker images
+    echo "Retagging and pushing images with tag: $TAG"
+    
+    # Only retag and push services that were built (based on BUILD_ARGS)
+    if [ "$PUSH_DEPS" = "yes" ]; then
+        echo "Retagging and pushing datastream-deps"
+        docker tag awiciroh/datastream-deps:latest-arm64 awiciroh/datastream-deps:$TAG
+        docker push awiciroh/datastream-deps:$TAG
+        docker push awiciroh/datastream-deps:latest-arm64
+    fi
+    
+    if [ "$PUSH_FP" = "yes" ]; then
+        echo "Retagging and pushing forcingprocessor"
+        docker tag awiciroh/forcingprocessor:latest-arm64 awiciroh/forcingprocessor:$TAG
+        docker push awiciroh/forcingprocessor:$TAG
+        docker push awiciroh/forcingprocessor:latest-arm64
+    fi
+    
+    if [ "$PUSH_DS" = "yes" ]; then
+        echo "Retagging and pushing datastream"
+        docker tag awiciroh/datastream:latest-arm64 awiciroh/datastream:$TAG
+        docker push awiciroh/datastream:$TAG
+        docker push awiciroh/datastream:latest-arm64
+    fi
+    
+    # Show what we have after operations
+    docker images
+    
+    echo "Retagging and pushing completed"
+    
 else
     echo "Docker login failed"
     exit 1
 fi
-

--- a/research_datastream/terraform/test/execution_gp_arm_docker_buildNtester.json
+++ b/research_datastream/terraform/test/execution_gp_arm_docker_buildNtester.json
@@ -1,10 +1,10 @@
 {  
   "commands"  : [
     "runuser -l ec2-user -c 'rm -rf /home/ec2-user/ngen-datastream && docker rmi -f $(docker images -aq)'",     
-    "runuser -l ec2-user -c 'cd /home/ec2-user && git clone https://github.com/CIROH-UA/ngen-datastream.git'",    
+    "runuser -l ec2-user -c 'cd /home/ec2-user && git clone -b release_tags https://github.com/CIROH-UA/ngen-datastream.git'",    
     "runuser -l ec2-user -c '/home/ec2-user/ngen-datastream/scripts/docker_builds.sh -e -f -d -t latest-arm64'",
-    "runuser -l ec2-user -c 'export DS_TAG=latest-arm FP_TAG=latest-arm && /home/ec2-user/ngen-datastream/scripts/datastream -s 202006200100 -e 202006200200 -C NWM_RETRO_V3 -d /home/ec2-user/ngen-datastream/data/datastream_test -g https://ngen-datastream.s3.us-east-2.amazonaws.com/palisade.gpkg -R /home/ec2-user/ngen-datastream/configs/ngen/realization_sloth_nom_cfe_pet.json'",
-    "runuser -l ec2-user -c '/home/ec2-user/ngen-datastream/research_datastream/terraform/test/docker_loginNpush.sh >> /home/ec2-user/ngen-datastream/docker_login_log.txt'",
+    "runuser -l ec2-user -c 'export DS_TAG=latest-arm64 FP_TAG=latest-arm64 && /home/ec2-user/ngen-datastream/scripts/datastream -s 202006200100 -e 202006200200 -C NWM_RETRO_V3 -d /home/ec2-user/ngen-datastream/data/datastream_test -g https://ngen-datastream.s3.us-east-2.amazonaws.com/palisade.gpkg -R /home/ec2-user/ngen-datastream/configs/ngen/realization_sloth_nom_cfe_pet.json'",
+    "runuser -l ec2-user -c '/home/ec2-user/ngen-datastream/research_datastream/terraform/test/docker_loginNpush.sh ${TAG} \"${BUILD_ARGS}\" >> /home/ec2-user/ngen-datastream/docker_login_log.txt'",
     "runuser -l ec2-user -c 'aws s3 cp /home/ec2-user/ngen-datastream/docker_login_log.txt s3://ciroh-community-ngen-datastream/docker_login_log.txt'",
     "runuser -l ec2-user -c 'aws s3 cp /home/ec2-user/ngen-datastream/docker_build_log.txt s3://ciroh-community-ngen-datastream/docker_build_log.txt'"
 ],
@@ -45,4 +45,3 @@
   ]
 }
 }
-

--- a/scripts/docker_builds.sh
+++ b/scripts/docker_builds.sh
@@ -5,14 +5,20 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DATASTREAM_PATH="$(dirname "$SCRIPT_DIR")"
 DOCKER_DIR="$DATASTREAM_PATH"/docker
 DOCKER_DATASTREAM=$DOCKER_DIR/ngen-datastream
-
 PLATFORM=$(uname -m)
 TAG="latest"
+
+cleanup_docker_datastream() {
+  if [ -d "$DOCKER_DATASTREAM" ]; then
+    rm -rf "$DOCKER_DATASTREAM"
+  fi
+}
 
 BUILD_FORCINGPROCESSOR="no"
 BUILD_DATASTREAM="no"
 PUSH="no"
 BUILD_DEPS="no"
+
 while getopts "pefdt:" flag; do
  case $flag in
    p) PUSH="yes"
@@ -23,45 +29,67 @@ while getopts "pefdt:" flag; do
    ;;
    d) BUILD_DATASTREAM="yes"
    ;;
+   a) BUILD_ALL="yes"
+   ;;
    t) TAG="$OPTARG"
    ;;
    \?)
    ;;
  esac
 done
+echo "Using TAG: $TAG"
+cd "$DOCKER_DIR"
 
-cd $DOCKER_DIR
 if [ "$BUILD_DEPS" = "yes" ]; then
-  docker build -t awiciroh/datastream-deps:$TAG -f Dockerfile.datastream-deps . --no-cache --build-arg ARCH=$PLATFORM
-  if [ -d "$DOCKER_DATASTREAM" ]; then
-    rm -rf $DOCKER_DATASTREAM
-  fi
+  echo "Building datastream-deps:$TAG"
+  docker build -t awiciroh/datastream-deps:$TAG \
+               -f Dockerfile.datastream-deps . --no-cache --build-arg ARCH=$PLATFORM
+  cleanup_docker_datastream
 fi
+
 if [ "$BUILD_FORCINGPROCESSOR" = "yes" ]; then
-  mkdir $DOCKER_DATASTREAM
-  cp -r $DATASTREAM_PATH/forcingprocessor $DOCKER_DATASTREAM/forcingprocessor
-  docker build -t awiciroh/forcingprocessor:$TAG -f Dockerfile.forcingprocessor . --no-cache --build-arg TAG_NAME=$TAG
-  if [ -d "$DOCKER_DATASTREAM" ]; then
-    rm -rf $DOCKER_DATASTREAM
-  fi
+  echo "Building forcingprocessor:$TAG"
+  mkdir "$DOCKER_DATASTREAM"
+  cp -r "$DATASTREAM_PATH"/forcingprocessor "$DOCKER_DATASTREAM"/forcingprocessor
+  docker build -t awiciroh/forcingprocessor:$TAG \
+               -f Dockerfile.forcingprocessor . --no-cache --build-arg TAG_NAME=$TAG
+  cleanup_docker_datastream
 fi
+
 if [ "$BUILD_DATASTREAM" = "yes" ]; then
-  mkdir $DOCKER_DATASTREAM
-  cp -r $DATASTREAM_PATH/python_tools $DOCKER_DATASTREAM/python_tools
-  cp -r $DATASTREAM_PATH/configs $DOCKER_DATASTREAM/configs
-  docker build -t awiciroh/datastream:$TAG -f Dockerfile.datastream . --no-cache --build-arg TAG_NAME=$TAG
-  if [ -d "$DOCKER_DATASTREAM" ]; then
-    rm -rf $DOCKER_DATASTREAM
-  fi
+  echo "Building datastream:$TAG"
+  mkdir "$DOCKER_DATASTREAM"
+  cp -r "$DATASTREAM_PATH"/python_tools "$DOCKER_DATASTREAM"/python_tools
+  cp -r "$DATASTREAM_PATH"/configs "$DOCKER_DATASTREAM"/configs
+  docker build -t awiciroh/datastream:$TAG \
+               -f Dockerfile.datastream . --no-cache --build-arg TAG_NAME=$TAG
+  cleanup_docker_datastream
 fi
 
 if [ "$PUSH" = "yes" ]; then
     echo "Pushing docker containers"
-    if [ "$SKIP_DEPS" = "no" ]; then
+    
+    # Only push what was actually built
+    if [ "$BUILD_DEPS" = "yes" ]; then
+      echo "Pushing datastream-deps"
       docker push awiciroh/datastream-deps:$TAG
     fi
-    docker push awiciroh/datastream-deps:$TAG
-    docker push awiciroh/datastream:$TAG
-    docker push awiciroh/forcingprocessor:$TAG
+    
+    if [ "$BUILD_FORCINGPROCESSOR" = "yes" ]; then
+      echo "Pushing forcingprocessor"
+      docker push awiciroh/forcingprocessor:$TAG
+    fi
+    
+    if [ "$BUILD_DATASTREAM" = "yes" ]; then
+      echo "Pushing datastream"
+      docker push awiciroh/datastream:$TAG
+    fi
+
+    if [ "$BUILD_ALL" = "yes" ]; then
+      echo "Pushing all the services"
+      docker push awiciroh/datastream-deps:$TAG
+      docker push awiciroh/forcingprocessor:$TAG
+      docker push awiciroh/datastream:$TAG
+    fi
     echo "Docker containers have been pushed to awiciroh dockerhub!"
 fi


### PR DESCRIPTION
This PR introduces a version-aware Docker build and push workflow that resolves reproducibility issues caused by overwriting the latest tag on DockerHub to solve [Issue 194](https://github.com/CIROH-UA/ngen-datastream/issues/194) A new versions.yml file has been added to explicitly track versions for datastream-deps, forcingprocessor, and datastream. The workflow automatically detects changes to this file compared to the previous commit and selectively builds and pushes only the services whose versions were updated(one service at a go).

When Docker images are first built, they are tagged with a temporary identifier such as latest-x86 or latest-arm64. These tags are used during the build and test phase so that the workflow can validate the containers before pushing them publicly. However, for reproducibility and versioning, we need to associate these images with explicit version tags (e.g., v1.2.0-x86 or v1.2.0-arm64) in addition to latest.

The retagging step takes the tested images (e.g., awiciroh/datastream:latest-arm64) and applies new tags based on the version specified in versions.yml.

The workflow supports multi-architecture builds for both x86 and ARM64. X86 builds are executed directly within GitHub Actions, while ARM64 builds are provisioned and tested through AWS Step Functions and EC2 using the execution_gp_arm_docker_buildNtester.json configuration.

To ensure cross-platform availability, the workflow also creates and publishes Docker manifests so that both latest and version tags reference multi-arch images. This approach preserves older container versions, reduces unnecessary rebuilds, and aligns with versioning principles for clarity in release management. As a result, reproducibility and traceability are significantly improved, allowing users to reliably reproduce past executions and track bug fixes or feature updates across releases.

This implementation has been tested successfully in the workflow run here: [GitHub Actions log](https://github.com/CIROH-UA/ngen-datastream/actions/runs/17136705685)
<img width="762" height="289" alt="Screenshot 2025-08-21 at 3 34 15 PM" src="https://github.com/user-attachments/assets/78abda39-29b2-414c-a6ba-5e0549de1726" />

Version changes triggered the appropriate builds, images were pushed to DockerHub with semantic version tags, and manifests were correctly published for both x86 and ARM64.
<img width="291" height="441" alt="Screenshot 2025-08-21 at 3 16 13 PM" src="https://github.com/user-attachments/assets/aa5eadf8-c9b8-49c7-b076-be28f4122522" />
