### PR TITLE
Fp bugs

### DIFF
--- a/.github/workflows/test_research_datastream_fp.yaml
+++ b/.github/workflows/test_research_datastream_fp.yaml
@@ -20,7 +20,7 @@ jobs:
   test-research-datastream-forcingprocessing:
     runs-on: ubuntu-latest
     env:
-      DATE: 20250801    
+      DATE: 20250803    
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -47,7 +47,7 @@ jobs:
         run: |
           cd research_datastream/terraform_community
           # Download the execution JSON
-          aws s3 cp s3://ciroh-community-ngen-datastream/v2.2/ngen.20250801/forcing_short_range/00/metadata/execution.json execution.json
+          aws s3 cp s3://ciroh-community-ngen-datastream/v2.2/ngen."${{ env.DATE }}"/forcing_short_range/00/metadata/execution.json execution.json
           # Remove specified fields and update TagSpecifications
           jq --arg DATE "${{ env.DATE }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions"}]}] | .commands |= map(sub("--s3_prefix(?i) \\K[^ ]+"; "tests/short_range/fp'\''")) | .commands |= map(gsub("--start_date DAILY"; "--start_date DAILY --end_date \($DATE)0000"))' execution.json > temp.json
           

--- a/ami_version.yml
+++ b/ami_version.yml
@@ -1,4 +1,4 @@
-datastream-ami-version: "1.9.7"
-DS_TAG: "latest"
-FP_TAG: "latest"
-NGIAB_TAG: "latest"
+datastream-ami-version: "1.6.4"
+DS_TAG: "1.0.2"
+FP_TAG: "1.0.2"
+NGIAB_TAG: "1.0.5"

--- a/forcingprocessor/src/forcingprocessor/processor.py
+++ b/forcingprocessor/src/forcingprocessor/processor.py
@@ -733,6 +733,7 @@ def prep_ngen_data(conf):
 
     log_time("STORE_METADATA_START", log_file)            
     global forcing_path
+    s3 = None
     if storage_type == "local":
         if output_path == "":
             output_path = os.path.join(os.getcwd(),datentime)        

--- a/forcingprocessor/src/forcingprocessor/weights_hf2ds.py
+++ b/forcingprocessor/src/forcingprocessor/weights_hf2ds.py
@@ -151,15 +151,19 @@ def hf2ds(files : list, raster : str, nf):
     """
     jcatchment_dict = {}
     count = 0
+    weights_dfs = []
     for jgpkg in files:
-        pattern = r"(?i)vpu[-_](\d+)"
+        pattern = r"(?i)vpu[-_](\d{2}[A-Z]?)"
         match = re.search(pattern, jgpkg)
         if match: jname = "VPU_" + match.group(1)
         else:
             count +=1
             jname = str(count)    
-        weights_df = hydrofabric2datastream_weights(jgpkg,raster,nf)
-        jcatchment_dict[jname] = list(weights_df.index)
+        jweights_df = hydrofabric2datastream_weights(jgpkg,raster,nf)
+        weights_dfs.append(jweights_df)
+        jcatchment_dict[jname] = list(jweights_df.index)
+
+    weights_df = pd.concat(weights_dfs)
 
     return weights_df, jcatchment_dict
 


### PR DESCRIPTION
This PR fixes a couple bugs in forcingprocessor related to reading in weights and writing out netcdfs to s3. In addition, the versions are explicitly set in `ami_versions.yml`.

## Additions

- None

## Removals

- None

## Changes

- Changed date in fp testing workflow to 03 to use a different execution, this is a temporary fix until execution file generation is implemented in actions
- Fixed weight file read in bug in fp. 
- Fixed bug in fp metadata writing to s3 in `write_df`
- Made tags explicit in `ami_version.yml`

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
