### PR TITLE
Verbose

### DIFF
--- a/docs/DATASTREAM_OPTIONS.md
+++ b/docs/DATASTREAM_OPTIONS.md
@@ -49,6 +49,7 @@ or run with cli args
 | NPROCS              | `-n` | Maximum number of processes to use in any step of  `ngen-datastream`. Defaults to `nprocs - 2` |  |
 | CONF_FILE            | `-c` | Store CLI args as env variables in a file. |  |
 | EVAL | `-E` | Set to "True" to run the TEEHR automated evaluation service on NextGen outputs. |  |
+| VERBOSE | `-V` | Set to "True" to output all of forcingprocessor and NGIAB outputs |  |
 
 ### Note for supplying file(s) paths
 DataStreamCLI is designed to pick up files or folder whether they are local, public, or in AWS s3 object storage.

--- a/scripts/datastream
+++ b/scripts/datastream
@@ -144,7 +144,7 @@ DO_TEEHR="False"
 VERBOSE="False"
 PIPE=""
 if [[ $VERBOSE == "True" ]]; then
-    PIPE=" > /dev/stdout 2>&1"
+    PIPE="> /dev/stdout 2>&1"
 fi
 
 PKL_FILE=""

--- a/scripts/datastream
+++ b/scripts/datastream
@@ -141,6 +141,11 @@ S3_PREFIX=""
 NPROCS=4
 DRYRUN="False"
 DO_TEEHR="False"
+VERBOSE="False"
+PIPE=""
+if [[ $VERBOSE == "True" ]]; then
+    PIPE=" > /dev/stdout 2>&1"
+fi
 
 PKL_FILE=""
 DATASTREAM_WEIGHTS=""
@@ -192,6 +197,7 @@ while [ "$#" -gt 0 ]; do
         -n|--NPROCS) NPROCS="$2"; shift 2;;
         -y|--DRYRUN) DRYRUN="$2"; shift 2;;
         -E|--EVAL) EVAL="$2"; shift 2;;
+        -V|--VERBOSE) EVAL="$2"; shift 2;;
         *) usage;;
     esac
 done
@@ -551,12 +557,12 @@ else
         echo "COMMAND: docker run --rm -v "$DATA_DIR:"$DOCKER_MOUNT"" \
             -u $(id -u):$(id -g) \
             -w "$DOCKER_RESOURCES" $DOCKER_TAG \
-            python3 "$DOCKER_FP"processor.py "$DOCKER_META"/conf_fp.json"
+            python3 "$DOCKER_FP"processor.py "$DOCKER_META"/conf_fp.json" $PIPE
     else
         log_n_run_steps docker run --rm -v "$DATA_DIR:"$DOCKER_MOUNT"" \
             -u $(id -u):$(id -g) \
             -w "$DOCKER_RESOURCES" $DOCKER_TAG \
-            python3 "$DOCKER_FP"processor.py "$DOCKER_META"/conf_fp.json
+            python3 "$DOCKER_FP"processor.py "$DOCKER_META"/conf_fp.json $PIPE
         FP_HASH=$(docker inspect --format='{{json .Id}}' $(docker image ls $DOCKER_TAG --format "{{.ID}}") | tr -d '"')
         # mv $DATASTREAM_RESOURCES/profile_fp.txt $DATASTREAM_META 
         log_time "FORCINGPROCESSOR_END"
@@ -615,9 +621,9 @@ log_time "NGEN_START"
 echo "Running NextGen in AUTO MODE from CIROH-UA/NGIAB-CloudInfra"
 if [ "$DRYRUN" == "True" ]; then
     echo "DRYRUN - NEXTGEN EXECUTION SKIPPED"
-    echo "COMMAND: docker run --rm -v "$NGEN_RUN":"$DOCKER_MOUNT" -u $(id -u):$(id -g) $NIGAB_TAG "$DOCKER_MOUNT" auto $NPROCS" local
+    echo "COMMAND: docker run --rm -v "$NGEN_RUN":"$DOCKER_MOUNT" -u $(id -u):$(id -g) $NIGAB_TAG "$DOCKER_MOUNT" auto $NPROCS" local $PIPE
 else    
-    log_n_run_steps docker run --rm -v "$NGEN_RUN":"$DOCKER_MOUNT" -u $(id -u):$(id -g) $NIGAB_TAG "$DOCKER_MOUNT" auto $NPROCS local > /dev/null 2>&1
+    log_n_run_steps docker run --rm -v "$NGEN_RUN":"$DOCKER_MOUNT" -u $(id -u):$(id -g) $NIGAB_TAG "$DOCKER_MOUNT" auto $NPROCS local $PIPE
     NGIAB_HASH=$(docker inspect --format='{{json .Id}}' $(docker image ls $NIGAB_TAG --format "{{.ID}}") | tr -d '"')
     cp -r $NGEN_RUN/*partitions* $DATASTREAM_RESOURCES_NGENCONF/
 fi


### PR DESCRIPTION
Adds an option (`VERBOSE`) to datastreamcli to print all of forcingprocessor and NGIAB outputs. Defaults to false. 

## Additions

- verbose option

## Removals

- none

## Changes

- none

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
