### PR TITLE
Build and test Docker ARM Containers

### DIFF
--- a/research_datastream/terraform/test/test_execution_gp_arm_docker_buildNtester.json
+++ b/research_datastream/terraform/test/test_execution_gp_arm_docker_buildNtester.json
@@ -1,0 +1,44 @@
+{  
+  "commands"  : [
+    "runuser -l ec2-user -c 'rm -rf /home/ec2-user/ngen-datastream && docker rmi -f $(docker images -aq)'",     
+    "runuser -l ec2-user -c 'cd /home/ec2-user && git clone https://github.com/CIROH-UA/ngen-datastream.git'",    
+    "runuser -l ec2-user -c '/home/ec2-user/ngen-datastream/scripts/docker_builds.sh -e -f -d -t latest-arm64'",
+    "runuser -l ec2-user -c 'export DS_TAG=latest-arm64 FP_TAG=latest-arm64 && /home/ec2-user/ngen-datastream/scripts/datastream -s 202006200100 -e 202006200200 -C NWM_RETRO_V3 -d /home/ec2-user/ngen-datastream/data/datastream_test -g https://ngen-datastream.s3.us-east-2.amazonaws.com/palisade.gpkg -R /home/ec2-user/ngen-datastream/configs/ngen/realization_sloth_nom_cfe_pet.json'"
+],
+"run_options":{
+  "ii_terminate_instance" : true,
+  "ii_delete_volume"      : true,
+  "ii_check_s3"           : false,
+  "timeout_s"             : 3600
+},
+"instance_parameters" :
+{
+  "ImageId"            : "ami-0be3c5d34679be688",
+  "InstanceType"       : "t4g.large",
+  "KeyName"            : "actions_key_arm",
+  "SecurityGroupIds"   : ["sg-0fcbe0c6d6faa0117"],
+  "IamInstanceProfile": {
+    "Name": "datastream_ec2_profile_github_actions_arm"
+  },
+  "TagSpecifications"   :[
+    {
+        "ResourceType": "instance",
+        "Tags": [
+            {
+                "Key"   : "Name",
+                "Value" : "arm_docker_buildNtester"
+            }
+        ]
+    }
+],
+  "BlockDeviceMappings":[
+    {
+        "DeviceName": "/dev/xvda",  
+        "Ebs": {
+            "VolumeSize": 32,
+            "VolumeType": "gp3"  
+        }
+    }
+  ]
+}
+}


### PR DESCRIPTION
Updated Files:-
build_test_docker_arm.yaml
test_execution_gp_arm_docker_buildNtester.json

The workflow now uses test_execution_gp_arm_docker_buildNtester, which is intended for testing only (no Docker image push). This file has been referenced in the execution configuration accordingly.