### PR TITLE
Add SSM command output logging to S3 (Traceability)

### DIFF
--- a/infra/aws/terraform/modules/orchestration/lambdas/streamcommander/lambda_function.py
+++ b/infra/aws/terraform/modules/orchestration/lambdas/streamcommander/lambda_function.py
@@ -36,6 +36,8 @@ def lambda_handler(event, context):
 
     instance_id = event['instance_parameters']['InstanceId']
 
+    bucket = None
+    prefix = None
 
     if "datastream_command_options" in event:
         ds_options = event["datastream_command_options"]
@@ -202,8 +204,10 @@ def lambda_handler(event, context):
                 InstanceIds=[instance_id],
                 DocumentName='AWS-RunShellScript',
                 Parameters={'commands': event['commands'],
-                            "executionTimeout": [f"{3600*24}"]
-                            }
+                            'executionTimeout': [f"{3600*24}"]
+                            },
+                OutputS3BucketName='ciroh-community-ngen-datastream',
+                OutputS3KeyPrefix=f"ssm-logs/{event.get('execution_name', today)}"
                 )
             ii_send_command = False
         except client_ssm.exceptions.ClientError as e:

--- a/infra/aws/terraform/modules/orchestration/statemachine.tf
+++ b/infra/aws/terraform/modules/orchestration/statemachine.tf
@@ -45,7 +45,7 @@ resource "aws_sfn_state_machine" "datastream_state_machine" {
       "Resource": "arn:aws:states:::lambda:invoke",
       "OutputPath": "$.Payload",
       "Parameters": {
-        "Payload.$": "$",
+        "Payload.$": "States.JsonMerge($, States.StringToJson(States.Format('\\{\"execution_name\":\"{}\"\\}', $$.Execution.Name)), false)",
         "FunctionName": "${aws_lambda_function.commander_lambda.arn}:$LATEST"
       },      
       "Retry": [


### PR DESCRIPTION
## Summary
- Add full EC2 command stdout/stderr logging to `s3://ciroh-community-ngen-datastream/ssm-logs/{execution_name}/` via SSM `OutputS3BucketName` and `OutputS3KeyPrefix`
- Inject Step Functions execution name into Commander Lambda payload using `States.JsonMerge` for traceable, browsable log paths
- Logs are organized by execution name (e.g., `ssm-logs/cfe_nom_short_range_00_VPU_07_20260211.../`) matching the Step Functions console

## S3 Log Folder Structure
```
ssm-logs/
  └── {execution_name}/                          ← matches Step Functions execution name
        └── {command_id}/                         ← SSM command ID
              └── {instance_id}/                  ← EC2 instance ID
                    └── awsrunShellScript/
                          └── 0.awsrunShellScript/
                                ├── stdout        ← full command output
                                └── stderr        ← full error output
```

## Lifecycle Configuration
```
aws s3api put-bucket-lifecycle-configuration \
  --bucket ciroh-community-ngen-datastream \
  --lifecycle-configuration '{
    "Rules": [
      {
        "ID": "DeleteSSMLogsAfter3Days",
        "Filter": {
          "Prefix": "ssm-logs/"
        },
        "Status": "Enabled",
        "Expiration": {
          "Days": 3
        }
      }
    ]
  }'
```
## Sample Output
- [stdout.txt](https://github.com/user-attachments/files/25242349/stdout.txt)

## Test plan
- [x] Deployed to `test_harsha` environment
- [x] Triggered state machine execution — Commander succeeded
- [x] Verified SSM logs written to `s3://ciroh-community-ngen-datastream/ssm-logs/test-exec-logging-20260211-123820/`
- [x] Confirmed full stdout (1.2 MB) and stderr (38 KB) captured without truncation
- [ ] Verify no impact on existing scheduled production executions