### PR TITLE
Consolidate S3 test prefixes under test/cicd/nrds/

### DIFF
--- a/.github/workflows/build_test_create_ami.yml
+++ b/.github/workflows/build_test_create_ami.yml
@@ -182,7 +182,7 @@ jobs:
           echo "AMI replacement completed for VPU ${{ env.VPU }}"
           echo "New AMI ID: $(jq -r '.instance_parameters.ImageId' execution.json)"
           
-          jq --arg DATE "${{ env.DATE }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions"}]}] | .commands |= map(sub("--s3_prefix(?i) \\K[^ ]+"; "tests/short_range/fp'\''")) | .commands |= map(gsub("--start_date DAILY"; "--start_date DAILY --end_date \($DATE)0000"))' execution.json > temp.json
+          jq --arg DATE "${{ env.DATE }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions"}]}] | .commands |= map(sub("--s3_prefix(?i) \\K[^ ]+"; "test/cicd/nrds/short_range/fp'\''")) | .commands |= map(gsub("--start_date DAILY"; "--start_date DAILY --end_date \($DATE)0000"))' execution.json > temp.json
 
 
       - name: Check and create AWS key pair
@@ -214,37 +214,37 @@ jobs:
 
       - name: Verify output files
         run: |
-          curl -fSs -o test_01.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_01.nc || { echo "Error: VPU_01 not found"; exit 1; }
-          curl -fSs -o test_02.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_02.nc || { echo "Error: VPU_02 not found"; exit 1; }
-          curl -fSs -o test_03W.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_03W.nc || { echo "Error: VPU_03W not found"; exit 1; }
-          curl -fSs -o test_03S.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_03S.nc || { echo "Error: VPU_03S not found"; exit 1; }
-          curl -fSs -o test_03N.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_03N.nc || { echo "Error: VPU_03N not found"; exit 1; }
-          curl -fSs -o test_04.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_04.nc || { echo "Error: VPU_04 not found"; exit 1; }
-          curl -fSs -o test_05.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_05.nc || { echo "Error: VPU_05 not found"; exit 1; }
-          curl -fSs -o test_06.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_06.nc || { echo "Error: VPU_06 not found"; exit 1; }
-          curl -fSs -o test_07.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_07.nc || { echo "Error: VPU_07 not found"; exit 1; }
-          curl -fSs -o test_08.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_08.nc || { echo "Error: VPU_08 not found"; exit 1; }
-          curl -fSs -o test_09.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_09.nc || { echo "Error: VPU_09 not found"; exit 1; }
-          curl -fSs -o test_10L.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_10L.nc || { echo "Error: VPU_10L not found"; exit 1; }
-          curl -fSs -o test_10U.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_10U.nc || { echo "Error: VPU_10U not found"; exit 1; }
-          curl -fSs -o test_11.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_11.nc || { echo "Error: VPU_11 not found"; exit 1; }
-          curl -fSs -o test_12.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_12.nc || { echo "Error: VPU_12 not found"; exit 1; }
-          curl -fSs -o test_13.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_13.nc || { echo "Error: VPU_13 not found"; exit 1; }
-          curl -fSs -o test_14.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_14.nc || { echo "Error: VPU_14 not found"; exit 1; }
-          curl -fSs -o test_15.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_15.nc || { echo "Error: VPU_15 not found"; exit 1; }
-          curl -fSs -o test_16.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_16.nc || { echo "Error: VPU_16 not found"; exit 1; }
-          curl -fSs -o test_17.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_17.nc || { echo "Error: VPU_17 not found"; exit 1; }
-          curl -fSs -o test_18.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_18.nc || { echo "Error: VPU_18 not found"; exit 1; }
+          curl -fSs -o test_01.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_01.nc || { echo "Error: VPU_01 not found"; exit 1; }
+          curl -fSs -o test_02.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_02.nc || { echo "Error: VPU_02 not found"; exit 1; }
+          curl -fSs -o test_03W.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_03W.nc || { echo "Error: VPU_03W not found"; exit 1; }
+          curl -fSs -o test_03S.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_03S.nc || { echo "Error: VPU_03S not found"; exit 1; }
+          curl -fSs -o test_03N.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_03N.nc || { echo "Error: VPU_03N not found"; exit 1; }
+          curl -fSs -o test_04.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_04.nc || { echo "Error: VPU_04 not found"; exit 1; }
+          curl -fSs -o test_05.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_05.nc || { echo "Error: VPU_05 not found"; exit 1; }
+          curl -fSs -o test_06.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_06.nc || { echo "Error: VPU_06 not found"; exit 1; }
+          curl -fSs -o test_07.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_07.nc || { echo "Error: VPU_07 not found"; exit 1; }
+          curl -fSs -o test_08.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_08.nc || { echo "Error: VPU_08 not found"; exit 1; }
+          curl -fSs -o test_09.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_09.nc || { echo "Error: VPU_09 not found"; exit 1; }
+          curl -fSs -o test_10L.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_10L.nc || { echo "Error: VPU_10L not found"; exit 1; }
+          curl -fSs -o test_10U.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_10U.nc || { echo "Error: VPU_10U not found"; exit 1; }
+          curl -fSs -o test_11.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_11.nc || { echo "Error: VPU_11 not found"; exit 1; }
+          curl -fSs -o test_12.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_12.nc || { echo "Error: VPU_12 not found"; exit 1; }
+          curl -fSs -o test_13.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_13.nc || { echo "Error: VPU_13 not found"; exit 1; }
+          curl -fSs -o test_14.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_14.nc || { echo "Error: VPU_14 not found"; exit 1; }
+          curl -fSs -o test_15.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_15.nc || { echo "Error: VPU_15 not found"; exit 1; }
+          curl -fSs -o test_16.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_16.nc || { echo "Error: VPU_16 not found"; exit 1; }
+          curl -fSs -o test_17.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_17.nc || { echo "Error: VPU_17 not found"; exit 1; }
+          curl -fSs -o test_18.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_18.nc || { echo "Error: VPU_18 not found"; exit 1; }
 
       - name: Debug - Check what files were created
         run: |
           echo "Checking what files were actually created..."
-          aws s3 ls s3://ciroh-community-ngen-datastream/tests/ --recursive
+          aws s3 ls s3://ciroh-community-ngen-datastream/test/cicd/nrds/ --recursive
 
       - name: Verify output files
         run: |
           echo "Checking if processing created any output files for FP..."
-          file_list=$(aws s3 ls s3://ciroh-community-ngen-datastream/tests/short_range/fp/ --recursive 2>/dev/null || echo "")
+          file_list=$(aws s3 ls s3://ciroh-community-ngen-datastream/test/cicd/nrds/short_range/fp/ --recursive 2>/dev/null || echo "")
           
           if [ -n "$file_list" ]; then
             echo "SUCCESS: FP processing completed successfully!"
@@ -258,7 +258,7 @@ jobs:
       - name: Clean up
         if: always()
         run: |
-          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/tests/short_range/fp || echo "No file to delete"
+          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/test/cicd/nrds/short_range/fp || echo "No file to delete"
 
 
   test-all-vpus:
@@ -331,7 +331,7 @@ jobs:
           echo "New AMI ID: $(jq -r '.instance_parameters.ImageId' execution.json)"
           
           # Apply jq transformations for this specific VPU
-          jq --arg DATE "${{ env.DATE }}" --arg VPU "${{ env.VPU }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions_vpu_\($VPU)"}, {"Key": "AMI_Version", "Value": "datastream-${{ needs.build-test-push-ami.outputs.ds_ami_version }}"}]}] | .commands |= map(sub("--S3_PREFIX(?i) \\K[^ ]+"; "tests/short_range/VPU_\($VPU)'\''")) | .commands |= map(gsub("VPU_16"; "VPU_\($VPU)")) | .commands |= map(gsub("-s DAILY"; "-s DAILY -e \($DATE)0000"))' execution.json > temp.json
+          jq --arg DATE "${{ env.DATE }}" --arg VPU "${{ env.VPU }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions_vpu_\($VPU)"}, {"Key": "AMI_Version", "Value": "datastream-${{ needs.build-test-push-ami.outputs.ds_ami_version }}"}]}] | .commands |= map(sub("--S3_PREFIX(?i) \\K[^ ]+"; "test/cicd/nrds/short_range/VPU_\($VPU)'\''")) | .commands |= map(gsub("VPU_16"; "VPU_\($VPU)")) | .commands |= map(gsub("-s DAILY"; "-s DAILY -e \($DATE)0000"))' execution.json > temp.json
 
 
       - name: Check and create AWS key pair
@@ -369,7 +369,7 @@ jobs:
           echo "Checking if processing created any output files for VPU ${{ env.VPU }}..."
           
           # Check if the directory exists and has files
-          file_list=$(aws s3 ls s3://ciroh-community-ngen-datastream/tests/short_range/VPU_${{ env.VPU }}/ --recursive 2>/dev/null || echo "")
+          file_list=$(aws s3 ls s3://ciroh-community-ngen-datastream/test/cicd/nrds/short_range/VPU_${{ env.VPU }}/ --recursive 2>/dev/null || echo "")
           
           if [ -n "$file_list" ]; then
             echo "SUCCESS: VPU ${{ env.VPU }} datastream processing completed successfully!"
@@ -394,12 +394,12 @@ jobs:
       - name: Verify output files
         if: matrix.vpu != '10U' && matrix.vpu != '17'
         run: |
-          curl -fSs -o test.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/VPU_${{ env.VPU }}/merkdir.file || { echo "Error: File not found or request failed"; exit 1; }
+          curl -fSs -o test.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/VPU_${{ env.VPU }}/merkdir.file || { echo "Error: File not found or request failed"; exit 1; }
 
       - name: Clean up
         if: always()
         run: |
-          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/tests/short_range/VPU_${{ env.VPU }} || echo "No files to delete for VPU ${{ env.VPU }}"
+          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/test/cicd/nrds/short_range/VPU_${{ env.VPU }} || echo "No files to delete for VPU ${{ env.VPU }}"
 
 
 

--- a/.github/workflows/build_test_ngiab_ami.yaml
+++ b/.github/workflows/build_test_ngiab_ami.yaml
@@ -257,7 +257,7 @@ jobs:
           echo "AMI replacement completed for VPU ${{ env.VPU }}"
           echo "New AMI ID: $(jq -r '.instance_parameters.ImageId' execution.json)"
           
-          jq --arg DATE "${{ env.DATE }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions"}]}] | .commands |= map(sub("--s3_prefix(?i) \\K[^ ]+"; "tests/short_range/fp'\''")) | .commands |= map(gsub("--start_date DAILY"; "--start_date DAILY --end_date \($DATE)0000"))' execution.json > temp.json
+          jq --arg DATE "${{ env.DATE }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions"}]}] | .commands |= map(sub("--s3_prefix(?i) \\K[^ ]+"; "test/cicd/nrds/short_range/fp'\''")) | .commands |= map(gsub("--start_date DAILY"; "--start_date DAILY --end_date \($DATE)0000"))' execution.json > temp.json
 
 
       - name: Check and create AWS key pair
@@ -289,37 +289,37 @@ jobs:
 
       - name: Verify output files
         run: |
-          curl -fSs -o test_01.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_01.nc || { echo "Error: VPU_01 not found"; exit 1; }
-          curl -fSs -o test_02.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_02.nc || { echo "Error: VPU_02 not found"; exit 1; }
-          curl -fSs -o test_03W.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_03W.nc || { echo "Error: VPU_03W not found"; exit 1; }
-          curl -fSs -o test_03S.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_03S.nc || { echo "Error: VPU_03S not found"; exit 1; }
-          curl -fSs -o test_03N.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_03N.nc || { echo "Error: VPU_03N not found"; exit 1; }
-          curl -fSs -o test_04.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_04.nc || { echo "Error: VPU_04 not found"; exit 1; }
-          curl -fSs -o test_05.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_05.nc || { echo "Error: VPU_05 not found"; exit 1; }
-          curl -fSs -o test_06.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_06.nc || { echo "Error: VPU_06 not found"; exit 1; }
-          curl -fSs -o test_07.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_07.nc || { echo "Error: VPU_07 not found"; exit 1; }
-          curl -fSs -o test_08.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_08.nc || { echo "Error: VPU_08 not found"; exit 1; }
-          curl -fSs -o test_09.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_09.nc || { echo "Error: VPU_09 not found"; exit 1; }
-          curl -fSs -o test_10L.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_10L.nc || { echo "Error: VPU_10L not found"; exit 1; }
-          curl -fSs -o test_10U.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_10U.nc || { echo "Error: VPU_10U not found"; exit 1; }
-          curl -fSs -o test_11.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_11.nc || { echo "Error: VPU_11 not found"; exit 1; }
-          curl -fSs -o test_12.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_12.nc || { echo "Error: VPU_12 not found"; exit 1; }
-          curl -fSs -o test_13.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_13.nc || { echo "Error: VPU_13 not found"; exit 1; }
-          curl -fSs -o test_14.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_14.nc || { echo "Error: VPU_14 not found"; exit 1; }
-          curl -fSs -o test_15.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_15.nc || { echo "Error: VPU_15 not found"; exit 1; }
-          curl -fSs -o test_16.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_16.nc || { echo "Error: VPU_16 not found"; exit 1; }
-          curl -fSs -o test_17.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_17.nc || { echo "Error: VPU_17 not found"; exit 1; }
-          curl -fSs -o test_18.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_18.nc || { echo "Error: VPU_18 not found"; exit 1; }
+          curl -fSs -o test_01.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_01.nc || { echo "Error: VPU_01 not found"; exit 1; }
+          curl -fSs -o test_02.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_02.nc || { echo "Error: VPU_02 not found"; exit 1; }
+          curl -fSs -o test_03W.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_03W.nc || { echo "Error: VPU_03W not found"; exit 1; }
+          curl -fSs -o test_03S.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_03S.nc || { echo "Error: VPU_03S not found"; exit 1; }
+          curl -fSs -o test_03N.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_03N.nc || { echo "Error: VPU_03N not found"; exit 1; }
+          curl -fSs -o test_04.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_04.nc || { echo "Error: VPU_04 not found"; exit 1; }
+          curl -fSs -o test_05.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_05.nc || { echo "Error: VPU_05 not found"; exit 1; }
+          curl -fSs -o test_06.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_06.nc || { echo "Error: VPU_06 not found"; exit 1; }
+          curl -fSs -o test_07.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_07.nc || { echo "Error: VPU_07 not found"; exit 1; }
+          curl -fSs -o test_08.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_08.nc || { echo "Error: VPU_08 not found"; exit 1; }
+          curl -fSs -o test_09.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_09.nc || { echo "Error: VPU_09 not found"; exit 1; }
+          curl -fSs -o test_10L.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_10L.nc || { echo "Error: VPU_10L not found"; exit 1; }
+          curl -fSs -o test_10U.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_10U.nc || { echo "Error: VPU_10U not found"; exit 1; }
+          curl -fSs -o test_11.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_11.nc || { echo "Error: VPU_11 not found"; exit 1; }
+          curl -fSs -o test_12.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_12.nc || { echo "Error: VPU_12 not found"; exit 1; }
+          curl -fSs -o test_13.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_13.nc || { echo "Error: VPU_13 not found"; exit 1; }
+          curl -fSs -o test_14.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_14.nc || { echo "Error: VPU_14 not found"; exit 1; }
+          curl -fSs -o test_15.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_15.nc || { echo "Error: VPU_15 not found"; exit 1; }
+          curl -fSs -o test_16.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_16.nc || { echo "Error: VPU_16 not found"; exit 1; }
+          curl -fSs -o test_17.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_17.nc || { echo "Error: VPU_17 not found"; exit 1; }
+          curl -fSs -o test_18.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_18.nc || { echo "Error: VPU_18 not found"; exit 1; }
 
       - name: Debug - Check what files were created
         run: |
           echo "Checking what files were actually created..."
-          aws s3 ls s3://ciroh-community-ngen-datastream/tests/ --recursive
+          aws s3 ls s3://ciroh-community-ngen-datastream/test/cicd/nrds/ --recursive
 
       - name: Verify output files
         run: |
           echo "Checking if processing created any output files for FP..."
-          file_list=$(aws s3 ls s3://ciroh-community-ngen-datastream/tests/short_range/fp/ --recursive 2>/dev/null || echo "")
+          file_list=$(aws s3 ls s3://ciroh-community-ngen-datastream/test/cicd/nrds/short_range/fp/ --recursive 2>/dev/null || echo "")
           
           if [ -n "$file_list" ]; then
             echo "SUCCESS: FP processing completed successfully!"
@@ -333,7 +333,7 @@ jobs:
       - name: Clean up
         if: always()
         run: |
-          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/tests/short_range/fp || echo "No file to delete"
+          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/test/cicd/nrds/short_range/fp || echo "No file to delete"
 
 
   test-all-vpus:
@@ -405,7 +405,7 @@ jobs:
           echo "New AMI ID: $(jq -r '.instance_parameters.ImageId' execution.json)"
           
           # Apply jq transformations for this specific VPU
-          jq --arg DATE "${{ env.DATE }}" --arg VPU "${{ env.VPU }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions_vpu_\($VPU)"}, {"Key": "AMI_Version", "Value": "datastream-${{ needs.build-test-push-ami.outputs.ds_ami_version }}"}]}] | .commands |= map(sub("--S3_PREFIX(?i) \\K[^ ]+"; "tests/short_range/VPU_\($VPU)'\''")) | .commands |= map(gsub("VPU_16"; "VPU_\($VPU)")) | .commands |= map(gsub("-s DAILY"; "-s DAILY -e \($DATE)0000"))' execution.json > temp.json
+          jq --arg DATE "${{ env.DATE }}" --arg VPU "${{ env.VPU }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions_vpu_\($VPU)"}, {"Key": "AMI_Version", "Value": "datastream-${{ needs.build-test-push-ami.outputs.ds_ami_version }}"}]}] | .commands |= map(sub("--S3_PREFIX(?i) \\K[^ ]+"; "test/cicd/nrds/short_range/VPU_\($VPU)'\''")) | .commands |= map(gsub("VPU_16"; "VPU_\($VPU)")) | .commands |= map(gsub("-s DAILY"; "-s DAILY -e \($DATE)0000"))' execution.json > temp.json
 
 
       - name: Check and create AWS key pair
@@ -443,7 +443,7 @@ jobs:
           echo "Checking if processing created any output files for VPU ${{ env.VPU }}..."
           
           # Check if the directory exists and has files
-          file_list=$(aws s3 ls s3://ciroh-community-ngen-datastream/tests/short_range/VPU_${{ env.VPU }}/ --recursive 2>/dev/null || echo "")
+          file_list=$(aws s3 ls s3://ciroh-community-ngen-datastream/test/cicd/nrds/short_range/VPU_${{ env.VPU }}/ --recursive 2>/dev/null || echo "")
           
           if [ -n "$file_list" ]; then
             echo "SUCCESS: VPU ${{ env.VPU }} datastream processing completed successfully!"
@@ -468,12 +468,12 @@ jobs:
       - name: Verify output files
         if: matrix.vpu != '10U' && matrix.vpu != '17'
         run: |
-          curl -fSs -o test.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/VPU_${{ env.VPU }}/merkdir.file || { echo "Error: File not found or request failed"; exit 1; }
+          curl -fSs -o test.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/VPU_${{ env.VPU }}/merkdir.file || { echo "Error: File not found or request failed"; exit 1; }
 
       - name: Clean up
         if: always()
         run: |
-          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/tests/short_range/VPU_${{ env.VPU }} || echo "No files to delete for VPU ${{ env.VPU }}"
+          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/test/cicd/nrds/short_range/VPU_${{ env.VPU }} || echo "No files to delete for VPU ${{ env.VPU }}"
 
 
 

--- a/.github/workflows/test_research_datastream_fp.yaml
+++ b/.github/workflows/test_research_datastream_fp.yaml
@@ -49,7 +49,7 @@ jobs:
           # Download the execution JSON
           aws s3 cp s3://ciroh-community-ngen-datastream/v2.2/ngen."${{ env.DATE }}"/forcing_short_range/00/metadata/execution.json execution.json
           # Remove specified fields and update TagSpecifications
-          jq --arg DATE "${{ env.DATE }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions"}]}] | .commands |= map(sub("--s3_prefix(?i) \\K[^ ]+"; "tests/short_range/fp'\''")) | .commands |= map(gsub("--start_date DAILY"; "--start_date DAILY --end_date \($DATE)0000"))' execution.json > temp.json
+          jq --arg DATE "${{ env.DATE }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions"}]}] | .commands |= map(sub("--s3_prefix(?i) \\K[^ ]+"; "test/cicd/nrds/short_range/fp'\''")) | .commands |= map(gsub("--start_date DAILY"; "--start_date DAILY --end_date \($DATE)0000"))' execution.json > temp.json
           
       - name: Check and create AWS key pair
         run: |
@@ -79,29 +79,29 @@ jobs:
 
       - name: Verify output files
         run: |
-          curl -fSs -o test_01.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_01.nc || { echo "Error: VPU_01 not found"; exit 1; }
-          curl -fSs -o test_02.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_02.nc || { echo "Error: VPU_02 not found"; exit 1; }
-          curl -fSs -o test_03W.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_03W.nc || { echo "Error: VPU_03W not found"; exit 1; }
-          curl -fSs -o test_03S.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_03S.nc || { echo "Error: VPU_03S not found"; exit 1; }
-          curl -fSs -o test_03N.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_03N.nc || { echo "Error: VPU_03N not found"; exit 1; }
-          curl -fSs -o test_04.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_04.nc || { echo "Error: VPU_04 not found"; exit 1; }
-          curl -fSs -o test_05.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_05.nc || { echo "Error: VPU_05 not found"; exit 1; }
-          curl -fSs -o test_06.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_06.nc || { echo "Error: VPU_06 not found"; exit 1; }
-          curl -fSs -o test_07.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_07.nc || { echo "Error: VPU_07 not found"; exit 1; }
-          curl -fSs -o test_08.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_08.nc || { echo "Error: VPU_08 not found"; exit 1; }
-          curl -fSs -o test_09.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_09.nc || { echo "Error: VPU_09 not found"; exit 1; }
-          curl -fSs -o test_10L.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_10L.nc || { echo "Error: VPU_10L not found"; exit 1; }
-          curl -fSs -o test_10U.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_10U.nc || { echo "Error: VPU_10U not found"; exit 1; }
-          curl -fSs -o test_11.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_11.nc || { echo "Error: VPU_11 not found"; exit 1; }
-          curl -fSs -o test_12.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_12.nc || { echo "Error: VPU_12 not found"; exit 1; }
-          curl -fSs -o test_13.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_13.nc || { echo "Error: VPU_13 not found"; exit 1; }
-          curl -fSs -o test_14.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_14.nc || { echo "Error: VPU_14 not found"; exit 1; }
-          curl -fSs -o test_15.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_15.nc || { echo "Error: VPU_15 not found"; exit 1; }
-          curl -fSs -o test_16.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_16.nc || { echo "Error: VPU_16 not found"; exit 1; }
-          curl -fSs -o test_17.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_17.nc || { echo "Error: VPU_17 not found"; exit 1; }
-          curl -fSs -o test_18.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_18.nc || { echo "Error: VPU_18 not found"; exit 1; }
+          curl -fSs -o test_01.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_01.nc || { echo "Error: VPU_01 not found"; exit 1; }
+          curl -fSs -o test_02.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_02.nc || { echo "Error: VPU_02 not found"; exit 1; }
+          curl -fSs -o test_03W.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_03W.nc || { echo "Error: VPU_03W not found"; exit 1; }
+          curl -fSs -o test_03S.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_03S.nc || { echo "Error: VPU_03S not found"; exit 1; }
+          curl -fSs -o test_03N.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_03N.nc || { echo "Error: VPU_03N not found"; exit 1; }
+          curl -fSs -o test_04.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_04.nc || { echo "Error: VPU_04 not found"; exit 1; }
+          curl -fSs -o test_05.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_05.nc || { echo "Error: VPU_05 not found"; exit 1; }
+          curl -fSs -o test_06.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_06.nc || { echo "Error: VPU_06 not found"; exit 1; }
+          curl -fSs -o test_07.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_07.nc || { echo "Error: VPU_07 not found"; exit 1; }
+          curl -fSs -o test_08.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_08.nc || { echo "Error: VPU_08 not found"; exit 1; }
+          curl -fSs -o test_09.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_09.nc || { echo "Error: VPU_09 not found"; exit 1; }
+          curl -fSs -o test_10L.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_10L.nc || { echo "Error: VPU_10L not found"; exit 1; }
+          curl -fSs -o test_10U.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_10U.nc || { echo "Error: VPU_10U not found"; exit 1; }
+          curl -fSs -o test_11.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_11.nc || { echo "Error: VPU_11 not found"; exit 1; }
+          curl -fSs -o test_12.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_12.nc || { echo "Error: VPU_12 not found"; exit 1; }
+          curl -fSs -o test_13.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_13.nc || { echo "Error: VPU_13 not found"; exit 1; }
+          curl -fSs -o test_14.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_14.nc || { echo "Error: VPU_14 not found"; exit 1; }
+          curl -fSs -o test_15.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_15.nc || { echo "Error: VPU_15 not found"; exit 1; }
+          curl -fSs -o test_16.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_16.nc || { echo "Error: VPU_16 not found"; exit 1; }
+          curl -fSs -o test_17.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_17.nc || { echo "Error: VPU_17 not found"; exit 1; }
+          curl -fSs -o test_18.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_18.nc || { echo "Error: VPU_18 not found"; exit 1; }
       
       - name: Clean up
         if: always()
         run: |
-          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/tests/short_range/fp || echo "No file to delete"          
+          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/test/cicd/nrds/short_range/fp || echo "No file to delete"          

--- a/.github/workflows/test_research_datastream_vpu_01.yaml
+++ b/.github/workflows/test_research_datastream_vpu_01.yaml
@@ -38,7 +38,7 @@ jobs:
           # Download the execution JSON
           aws s3 cp s3://ciroh-community-ngen-datastream/v2.2/ngen.${{ env.DATE }}/short_range/00/VPU_16/datastream-metadata/execution.json execution.json
           # Remove specified fields, update TagSpecifications, and modify S3 prefix in commands
-          jq --arg VPU "${{ env.VPU }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions"}]}] | .commands |= map(sub("--S3_PREFIX(?i) \\K[^ ]+"; "tests/short_range/VPU_\($VPU)'\''")) | .commands |= map(gsub("VPU_16"; "VPU_\($VPU)"))' execution.json > temp.json
+          jq --arg VPU "${{ env.VPU }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions"}]}] | .commands |= map(sub("--S3_PREFIX(?i) \\K[^ ]+"; "test/cicd/nrds/short_range/VPU_\($VPU)'\''")) | .commands |= map(gsub("VPU_16"; "VPU_\($VPU)"))' execution.json > temp.json
           
       - name: Check and create AWS key pair
         run: |
@@ -68,9 +68,9 @@ jobs:
 
       - name: Verify output file
         run: |
-          curl -fSs -o test.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/VPU_${{ env.VPU }}/merkdir.file || { echo "Error: File not found or request failed"; exit 1; }
+          curl -fSs -o test.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/VPU_${{ env.VPU }}/merkdir.file || { echo "Error: File not found or request failed"; exit 1; }
 
       - name: Clean up
         if: always()
         run: |
-          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/tests/short_range/VPU_${{ env.VPU }} || echo "No file to delete"
+          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/test/cicd/nrds/short_range/VPU_${{ env.VPU }} || echo "No file to delete"

--- a/.github/workflows/test_research_datastream_vpu_02.yaml
+++ b/.github/workflows/test_research_datastream_vpu_02.yaml
@@ -38,7 +38,7 @@ jobs:
           # Download the execution JSON
           aws s3 cp s3://ciroh-community-ngen-datastream/v2.2/ngen.${{ env.DATE }}/short_range/00/VPU_16/datastream-metadata/execution.json execution.json
           # Remove specified fields, update TagSpecifications, and modify S3 prefix in commands
-          jq --arg VPU "${{ env.VPU }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions"}]}] | .commands |= map(sub("--S3_PREFIX(?i) \\K[^ ]+"; "tests/short_range/VPU_\($VPU)'\''")) | .commands |= map(gsub("VPU_16"; "VPU_\($VPU)"))' execution.json > temp.json
+          jq --arg VPU "${{ env.VPU }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions"}]}] | .commands |= map(sub("--S3_PREFIX(?i) \\K[^ ]+"; "test/cicd/nrds/short_range/VPU_\($VPU)'\''")) | .commands |= map(gsub("VPU_16"; "VPU_\($VPU)"))' execution.json > temp.json
           
       - name: Check and create AWS key pair
         run: |
@@ -68,9 +68,9 @@ jobs:
 
       - name: Verify output file
         run: |
-          curl -fSs -o test.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/VPU_${{ env.VPU }}/merkdir.file || { echo "Error: File not found or request failed"; exit 1; }
+          curl -fSs -o test.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/VPU_${{ env.VPU }}/merkdir.file || { echo "Error: File not found or request failed"; exit 1; }
 
       - name: Clean up
         if: always()
         run: |
-          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/tests/short_range/VPU_${{ env.VPU }} || echo "No file to delete"
+          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/test/cicd/nrds/short_range/VPU_${{ env.VPU }} || echo "No file to delete"

--- a/.github/workflows/test_research_datastream_vpu_03N.yaml
+++ b/.github/workflows/test_research_datastream_vpu_03N.yaml
@@ -38,7 +38,7 @@ jobs:
           # Download the execution JSON
           aws s3 cp s3://ciroh-community-ngen-datastream/v2.2/ngen.${{ env.DATE }}/short_range/00/VPU_16/datastream-metadata/execution.json execution.json
           # Remove specified fields, update TagSpecifications, and modify S3 prefix in commands
-          jq --arg VPU "${{ env.VPU }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions"}]}] | .commands |= map(sub("--S3_PREFIX(?i) \\K[^ ]+"; "tests/short_range/VPU_\($VPU)'\''")) | .commands |= map(gsub("VPU_16"; "VPU_\($VPU)"))' execution.json > temp.json
+          jq --arg VPU "${{ env.VPU }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions"}]}] | .commands |= map(sub("--S3_PREFIX(?i) \\K[^ ]+"; "test/cicd/nrds/short_range/VPU_\($VPU)'\''")) | .commands |= map(gsub("VPU_16"; "VPU_\($VPU)"))' execution.json > temp.json
           
       - name: Check and create AWS key pair
         run: |
@@ -68,9 +68,9 @@ jobs:
 
       - name: Verify output file
         run: |
-          curl -fSs -o test.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/VPU_${{ env.VPU }}/merkdir.file || { echo "Error: File not found or request failed"; exit 1; }
+          curl -fSs -o test.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/VPU_${{ env.VPU }}/merkdir.file || { echo "Error: File not found or request failed"; exit 1; }
 
       - name: Clean up
         if: always()
         run: |
-          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/tests/short_range/VPU_${{ env.VPU }} || echo "No file to delete"
+          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/test/cicd/nrds/short_range/VPU_${{ env.VPU }} || echo "No file to delete"

--- a/.github/workflows/test_research_datastream_vpu_03S.yaml
+++ b/.github/workflows/test_research_datastream_vpu_03S.yaml
@@ -38,7 +38,7 @@ jobs:
           # Download the execution JSON
           aws s3 cp s3://ciroh-community-ngen-datastream/v2.2/ngen.${{ env.DATE }}/short_range/00/VPU_16/datastream-metadata/execution.json execution.json
           # Remove specified fields, update TagSpecifications, and modify S3 prefix in commands
-          jq --arg VPU "${{ env.VPU }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions"}]}] | .commands |= map(sub("--S3_PREFIX(?i) \\K[^ ]+"; "tests/short_range/VPU_\($VPU)'\''")) | .commands |= map(gsub("VPU_16"; "VPU_\($VPU)"))' execution.json > temp.json
+          jq --arg VPU "${{ env.VPU }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions"}]}] | .commands |= map(sub("--S3_PREFIX(?i) \\K[^ ]+"; "test/cicd/nrds/short_range/VPU_\($VPU)'\''")) | .commands |= map(gsub("VPU_16"; "VPU_\($VPU)"))' execution.json > temp.json
           
       - name: Check and create AWS key pair
         run: |
@@ -68,9 +68,9 @@ jobs:
 
       - name: Verify output file
         run: |
-          curl -fSs -o test.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/VPU_${{ env.VPU }}/merkdir.file || { echo "Error: File not found or request failed"; exit 1; }
+          curl -fSs -o test.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/VPU_${{ env.VPU }}/merkdir.file || { echo "Error: File not found or request failed"; exit 1; }
 
       - name: Clean up
         if: always()
         run: |
-          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/tests/short_range/VPU_${{ env.VPU }} || echo "No file to delete"
+          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/test/cicd/nrds/short_range/VPU_${{ env.VPU }} || echo "No file to delete"

--- a/.github/workflows/test_research_datastream_vpu_03W.yaml
+++ b/.github/workflows/test_research_datastream_vpu_03W.yaml
@@ -38,7 +38,7 @@ jobs:
           # Download the execution JSON
           aws s3 cp s3://ciroh-community-ngen-datastream/v2.2/ngen.${{ env.DATE }}/short_range/00/VPU_16/datastream-metadata/execution.json execution.json
           # Remove specified fields, update TagSpecifications, and modify S3 prefix in commands
-          jq --arg VPU "${{ env.VPU }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions"}]}] | .commands |= map(sub("--S3_PREFIX(?i) \\K[^ ]+"; "tests/short_range/VPU_\($VPU)'\''")) | .commands |= map(gsub("VPU_16"; "VPU_\($VPU)"))' execution.json > temp.json
+          jq --arg VPU "${{ env.VPU }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions"}]}] | .commands |= map(sub("--S3_PREFIX(?i) \\K[^ ]+"; "test/cicd/nrds/short_range/VPU_\($VPU)'\''")) | .commands |= map(gsub("VPU_16"; "VPU_\($VPU)"))' execution.json > temp.json
           
       - name: Check and create AWS key pair
         run: |
@@ -68,9 +68,9 @@ jobs:
 
       - name: Verify output file
         run: |
-          curl -fSs -o test.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/VPU_${{ env.VPU }}/merkdir.file || { echo "Error: File not found or request failed"; exit 1; }
+          curl -fSs -o test.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/VPU_${{ env.VPU }}/merkdir.file || { echo "Error: File not found or request failed"; exit 1; }
 
       - name: Clean up
         if: always()
         run: |
-          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/tests/short_range/VPU_${{ env.VPU }} || echo "No file to delete"
+          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/test/cicd/nrds/short_range/VPU_${{ env.VPU }} || echo "No file to delete"

--- a/.github/workflows/test_research_datastream_vpu_04.yaml
+++ b/.github/workflows/test_research_datastream_vpu_04.yaml
@@ -38,7 +38,7 @@ jobs:
           # Download the execution JSON
           aws s3 cp s3://ciroh-community-ngen-datastream/v2.2/ngen.${{ env.DATE }}/short_range/00/VPU_16/datastream-metadata/execution.json execution.json
           # Remove specified fields, update TagSpecifications, and modify S3 prefix in commands
-          jq --arg VPU "${{ env.VPU }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions"}]}] | .commands |= map(sub("--S3_PREFIX(?i) \\K[^ ]+"; "tests/short_range/VPU_\($VPU)'\''")) | .commands |= map(gsub("VPU_16"; "VPU_\($VPU)"))' execution.json > temp.json
+          jq --arg VPU "${{ env.VPU }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions"}]}] | .commands |= map(sub("--S3_PREFIX(?i) \\K[^ ]+"; "test/cicd/nrds/short_range/VPU_\($VPU)'\''")) | .commands |= map(gsub("VPU_16"; "VPU_\($VPU)"))' execution.json > temp.json
           
       - name: Check and create AWS key pair
         run: |
@@ -68,9 +68,9 @@ jobs:
 
       - name: Verify output file
         run: |
-          curl -fSs -o test.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/VPU_${{ env.VPU }}/merkdir.file || { echo "Error: File not found or request failed"; exit 1; }
+          curl -fSs -o test.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/VPU_${{ env.VPU }}/merkdir.file || { echo "Error: File not found or request failed"; exit 1; }
 
       - name: Clean up
         if: always()
         run: |
-          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/tests/short_range/VPU_${{ env.VPU }} || echo "No file to delete"
+          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/test/cicd/nrds/short_range/VPU_${{ env.VPU }} || echo "No file to delete"

--- a/.github/workflows/test_research_datastream_vpu_05.yaml
+++ b/.github/workflows/test_research_datastream_vpu_05.yaml
@@ -38,7 +38,7 @@ jobs:
           # Download the execution JSON
           aws s3 cp s3://ciroh-community-ngen-datastream/v2.2/ngen.${{ env.DATE }}/short_range/00/VPU_16/datastream-metadata/execution.json execution.json
           # Remove specified fields, update TagSpecifications, and modify S3 prefix in commands
-          jq --arg VPU "${{ env.VPU }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions"}]}] | .commands |= map(sub("--S3_PREFIX(?i) \\K[^ ]+"; "tests/short_range/VPU_\($VPU)'\''")) | .commands |= map(gsub("VPU_16"; "VPU_\($VPU)"))' execution.json > temp.json
+          jq --arg VPU "${{ env.VPU }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions"}]}] | .commands |= map(sub("--S3_PREFIX(?i) \\K[^ ]+"; "test/cicd/nrds/short_range/VPU_\($VPU)'\''")) | .commands |= map(gsub("VPU_16"; "VPU_\($VPU)"))' execution.json > temp.json
           
       - name: Check and create AWS key pair
         run: |
@@ -68,9 +68,9 @@ jobs:
 
       - name: Verify output file
         run: |
-          curl -fSs -o test.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/VPU_${{ env.VPU }}/merkdir.file || { echo "Error: File not found or request failed"; exit 1; }
+          curl -fSs -o test.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/VPU_${{ env.VPU }}/merkdir.file || { echo "Error: File not found or request failed"; exit 1; }
 
       - name: Clean up
         if: always()
         run: |
-          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/tests/short_range/VPU_${{ env.VPU }} || echo "No file to delete"
+          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/test/cicd/nrds/short_range/VPU_${{ env.VPU }} || echo "No file to delete"

--- a/.github/workflows/test_research_datastream_vpu_06.yaml
+++ b/.github/workflows/test_research_datastream_vpu_06.yaml
@@ -38,7 +38,7 @@ jobs:
           # Download the execution JSON
           aws s3 cp s3://ciroh-community-ngen-datastream/v2.2/ngen.${{ env.DATE }}/short_range/00/VPU_16/datastream-metadata/execution.json execution.json
           # Remove specified fields, update TagSpecifications, and modify S3 prefix in commands
-          jq --arg VPU "${{ env.VPU }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions"}]}] | .commands |= map(sub("--S3_PREFIX(?i) \\K[^ ]+"; "tests/short_range/VPU_\($VPU)'\''")) | .commands |= map(gsub("VPU_16"; "VPU_\($VPU)"))' execution.json > temp.json
+          jq --arg VPU "${{ env.VPU }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions"}]}] | .commands |= map(sub("--S3_PREFIX(?i) \\K[^ ]+"; "test/cicd/nrds/short_range/VPU_\($VPU)'\''")) | .commands |= map(gsub("VPU_16"; "VPU_\($VPU)"))' execution.json > temp.json
           
       - name: Check and create AWS key pair
         run: |
@@ -68,9 +68,9 @@ jobs:
 
       - name: Verify output file
         run: |
-          curl -fSs -o test.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/VPU_${{ env.VPU }}/merkdir.file || { echo "Error: File not found or request failed"; exit 1; }
+          curl -fSs -o test.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/VPU_${{ env.VPU }}/merkdir.file || { echo "Error: File not found or request failed"; exit 1; }
 
       - name: Clean up
         if: always()
         run: |
-          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/tests/short_range/VPU_${{ env.VPU }} || echo "No file to delete"
+          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/test/cicd/nrds/short_range/VPU_${{ env.VPU }} || echo "No file to delete"

--- a/.github/workflows/test_research_datastream_vpu_07.yaml
+++ b/.github/workflows/test_research_datastream_vpu_07.yaml
@@ -38,7 +38,7 @@ jobs:
           # Download the execution JSON
           aws s3 cp s3://ciroh-community-ngen-datastream/v2.2/ngen.${{ env.DATE }}/short_range/00/VPU_16/datastream-metadata/execution.json execution.json
           # Remove specified fields, update TagSpecifications, and modify S3 prefix in commands
-          jq --arg VPU "${{ env.VPU }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions"}]}] | .commands |= map(sub("--S3_PREFIX(?i) \\K[^ ]+"; "tests/short_range/VPU_\($VPU)'\''")) | .commands |= map(gsub("VPU_16"; "VPU_\($VPU)"))' execution.json > temp.json
+          jq --arg VPU "${{ env.VPU }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions"}]}] | .commands |= map(sub("--S3_PREFIX(?i) \\K[^ ]+"; "test/cicd/nrds/short_range/VPU_\($VPU)'\''")) | .commands |= map(gsub("VPU_16"; "VPU_\($VPU)"))' execution.json > temp.json
           
       - name: Check and create AWS key pair
         run: |
@@ -68,9 +68,9 @@ jobs:
 
       - name: Verify output file
         run: |
-          curl -fSs -o test.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/VPU_${{ env.VPU }}/merkdir.file || { echo "Error: File not found or request failed"; exit 1; }
+          curl -fSs -o test.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/VPU_${{ env.VPU }}/merkdir.file || { echo "Error: File not found or request failed"; exit 1; }
 
       - name: Clean up
         if: always()
         run: |
-          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/tests/short_range/VPU_${{ env.VPU }} || echo "No file to delete"
+          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/test/cicd/nrds/short_range/VPU_${{ env.VPU }} || echo "No file to delete"

--- a/.github/workflows/test_research_datastream_vpu_08.yaml
+++ b/.github/workflows/test_research_datastream_vpu_08.yaml
@@ -38,7 +38,7 @@ jobs:
           # Download the execution JSON
           aws s3 cp s3://ciroh-community-ngen-datastream/v2.2/ngen.${{ env.DATE }}/short_range/00/VPU_16/datastream-metadata/execution.json execution.json
           # Remove specified fields, update TagSpecifications, and modify S3 prefix in commands
-          jq --arg VPU "${{ env.VPU }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions"}]}] | .commands |= map(sub("--S3_PREFIX(?i) \\K[^ ]+"; "tests/short_range/VPU_\($VPU)'\''")) | .commands |= map(gsub("VPU_16"; "VPU_\($VPU)"))' execution.json > temp.json
+          jq --arg VPU "${{ env.VPU }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions"}]}] | .commands |= map(sub("--S3_PREFIX(?i) \\K[^ ]+"; "test/cicd/nrds/short_range/VPU_\($VPU)'\''")) | .commands |= map(gsub("VPU_16"; "VPU_\($VPU)"))' execution.json > temp.json
           
       - name: Check and create AWS key pair
         run: |
@@ -68,9 +68,9 @@ jobs:
 
       - name: Verify output file
         run: |
-          curl -fSs -o test.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/VPU_${{ env.VPU }}/merkdir.file || { echo "Error: File not found or request failed"; exit 1; }
+          curl -fSs -o test.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/VPU_${{ env.VPU }}/merkdir.file || { echo "Error: File not found or request failed"; exit 1; }
 
       - name: Clean up
         if: always()
         run: |
-          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/tests/short_range/VPU_${{ env.VPU }} || echo "No file to delete"
+          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/test/cicd/nrds/short_range/VPU_${{ env.VPU }} || echo "No file to delete"

--- a/.github/workflows/test_research_datastream_vpu_09.yaml
+++ b/.github/workflows/test_research_datastream_vpu_09.yaml
@@ -73,7 +73,7 @@ jobs:
           # Download the execution JSON
           aws s3 cp s3://ciroh-community-ngen-datastream/v2.2/ngen.${{ env.DATE }}/short_range/00/VPU_16/datastream-metadata/execution.json execution.json
           # Remove specified fields, update TagSpecifications, and modify S3 prefix in commands
-          jq --arg DATE "${{ env.DATE }}" --arg VPU "${{ env.VPU }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions"}]}] | .commands |= map(sub("--S3_PREFIX(?i) \\K[^ ]+"; "tests/short_range/VPU_\($VPU)'\''")) | .commands |= map(gsub("VPU_16"; "VPU_\($VPU)")) | .commands |= map(gsub("-s DAILY"; "-s DAILY -e \($DATE)0000"))' execution.json > temp.json
+          jq --arg DATE "${{ env.DATE }}" --arg VPU "${{ env.VPU }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions"}]}] | .commands |= map(sub("--S3_PREFIX(?i) \\K[^ ]+"; "test/cicd/nrds/short_range/VPU_\($VPU)'\''")) | .commands |= map(gsub("VPU_16"; "VPU_\($VPU)")) | .commands |= map(gsub("-s DAILY"; "-s DAILY -e \($DATE)0000"))' execution.json > temp.json
 
       - name: Check and create AWS key pair
         run: |
@@ -103,9 +103,9 @@ jobs:
 
       - name: Verify output file
         run: |
-          curl -fSs -o test.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/VPU_${{ env.VPU }}/merkdir.file || { echo "Error: File not found or request failed"; exit 1; }
+          curl -fSs -o test.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/VPU_${{ env.VPU }}/merkdir.file || { echo "Error: File not found or request failed"; exit 1; }
 
       - name: Clean up
         if: always()
         run: |
-          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/tests/short_range/VPU_${{ env.VPU }} || echo "No file to delete"
+          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/test/cicd/nrds/short_range/VPU_${{ env.VPU }} || echo "No file to delete"

--- a/.github/workflows/test_research_datastream_vpu_10L.yaml
+++ b/.github/workflows/test_research_datastream_vpu_10L.yaml
@@ -38,7 +38,7 @@ jobs:
           # Download the execution JSON
           aws s3 cp s3://ciroh-community-ngen-datastream/v2.2/ngen.${{ env.DATE }}/short_range/00/VPU_16/datastream-metadata/execution.json execution.json
           # Remove specified fields, update TagSpecifications, and modify S3 prefix in commands
-          jq --arg VPU "${{ env.VPU }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions"}]}] | .commands |= map(sub("--S3_PREFIX(?i) \\K[^ ]+"; "tests/short_range/VPU_\($VPU)'\''")) | .commands |= map(gsub("VPU_16"; "VPU_\($VPU)"))' execution.json > temp.json
+          jq --arg VPU "${{ env.VPU }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions"}]}] | .commands |= map(sub("--S3_PREFIX(?i) \\K[^ ]+"; "test/cicd/nrds/short_range/VPU_\($VPU)'\''")) | .commands |= map(gsub("VPU_16"; "VPU_\($VPU)"))' execution.json > temp.json
           
       - name: Check and create AWS key pair
         run: |
@@ -68,9 +68,9 @@ jobs:
 
       - name: Verify output file
         run: |
-          curl -fSs -o test.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/VPU_${{ env.VPU }}/merkdir.file || { echo "Error: File not found or request failed"; exit 1; }
+          curl -fSs -o test.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/VPU_${{ env.VPU }}/merkdir.file || { echo "Error: File not found or request failed"; exit 1; }
 
       - name: Clean up
         if: always()
         run: |
-          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/tests/short_range/VPU_${{ env.VPU }} || echo "No file to delete"
+          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/test/cicd/nrds/short_range/VPU_${{ env.VPU }} || echo "No file to delete"

--- a/.github/workflows/test_research_datastream_vpu_10U.yaml
+++ b/.github/workflows/test_research_datastream_vpu_10U.yaml
@@ -38,7 +38,7 @@ jobs:
           # Download the execution JSON
           aws s3 cp s3://ciroh-community-ngen-datastream/v2.2/ngen.${{ env.DATE }}/short_range/00/VPU_16/datastream-metadata/execution.json execution.json
           # Remove specified fields, update TagSpecifications, and modify S3 prefix in commands
-          jq --arg VPU "${{ env.VPU }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions"}]}] | .commands |= map(sub("--S3_PREFIX(?i) \\K[^ ]+"; "tests/short_range/VPU_\($VPU)'\''")) | .commands |= map(gsub("VPU_16"; "VPU_\($VPU)"))' execution.json > temp.json
+          jq --arg VPU "${{ env.VPU }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions"}]}] | .commands |= map(sub("--S3_PREFIX(?i) \\K[^ ]+"; "test/cicd/nrds/short_range/VPU_\($VPU)'\''")) | .commands |= map(gsub("VPU_16"; "VPU_\($VPU)"))' execution.json > temp.json
           
       - name: Check and create AWS key pair
         run: |
@@ -68,9 +68,9 @@ jobs:
 
       - name: Verify output file
         run: |
-          curl -fSs -o test.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/VPU_${{ env.VPU }}/merkdir.file || { echo "Error: File not found or request failed"; exit 1; }
+          curl -fSs -o test.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/VPU_${{ env.VPU }}/merkdir.file || { echo "Error: File not found or request failed"; exit 1; }
 
       - name: Clean up
         if: always()
         run: |
-          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/tests/short_range/VPU_${{ env.VPU }} || echo "No file to delete"
+          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/test/cicd/nrds/short_range/VPU_${{ env.VPU }} || echo "No file to delete"

--- a/.github/workflows/test_research_datastream_vpu_11.yaml
+++ b/.github/workflows/test_research_datastream_vpu_11.yaml
@@ -38,7 +38,7 @@ jobs:
           # Download the execution JSON
           aws s3 cp s3://ciroh-community-ngen-datastream/v2.2/ngen.${{ env.DATE }}/short_range/00/VPU_16/datastream-metadata/execution.json execution.json
           # Remove specified fields, update TagSpecifications, and modify S3 prefix in commands
-          jq --arg VPU "${{ env.VPU }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions"}]}] | .commands |= map(sub("--S3_PREFIX(?i) \\K[^ ]+"; "tests/short_range/VPU_\($VPU)'\''")) | .commands |= map(gsub("VPU_16"; "VPU_\($VPU)"))' execution.json > temp.json
+          jq --arg VPU "${{ env.VPU }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions"}]}] | .commands |= map(sub("--S3_PREFIX(?i) \\K[^ ]+"; "test/cicd/nrds/short_range/VPU_\($VPU)'\''")) | .commands |= map(gsub("VPU_16"; "VPU_\($VPU)"))' execution.json > temp.json
           
       - name: Check and create AWS key pair
         run: |
@@ -68,9 +68,9 @@ jobs:
 
       - name: Verify output file
         run: |
-          curl -fSs -o test.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/VPU_${{ env.VPU }}/merkdir.file || { echo "Error: File not found or request failed"; exit 1; }
+          curl -fSs -o test.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/VPU_${{ env.VPU }}/merkdir.file || { echo "Error: File not found or request failed"; exit 1; }
 
       - name: Clean up
         if: always()
         run: |
-          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/tests/short_range/VPU_${{ env.VPU }} || echo "No file to delete"
+          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/test/cicd/nrds/short_range/VPU_${{ env.VPU }} || echo "No file to delete"

--- a/.github/workflows/test_research_datastream_vpu_12.yaml
+++ b/.github/workflows/test_research_datastream_vpu_12.yaml
@@ -38,7 +38,7 @@ jobs:
           # Download the execution JSON
           aws s3 cp s3://ciroh-community-ngen-datastream/v2.2/ngen.${{ env.DATE }}/short_range/00/VPU_16/datastream-metadata/execution.json execution.json
           # Remove specified fields, update TagSpecifications, and modify S3 prefix in commands
-          jq --arg VPU "${{ env.VPU }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions"}]}] | .commands |= map(sub("--S3_PREFIX(?i) \\K[^ ]+"; "tests/short_range/VPU_\($VPU)'\''")) | .commands |= map(gsub("VPU_16"; "VPU_\($VPU)"))' execution.json > temp.json
+          jq --arg VPU "${{ env.VPU }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions"}]}] | .commands |= map(sub("--S3_PREFIX(?i) \\K[^ ]+"; "test/cicd/nrds/short_range/VPU_\($VPU)'\''")) | .commands |= map(gsub("VPU_16"; "VPU_\($VPU)"))' execution.json > temp.json
           
       - name: Check and create AWS key pair
         run: |
@@ -68,9 +68,9 @@ jobs:
 
       - name: Verify output file
         run: |
-          curl -fSs -o test.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/VPU_${{ env.VPU }}/merkdir.file || { echo "Error: File not found or request failed"; exit 1; }
+          curl -fSs -o test.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/VPU_${{ env.VPU }}/merkdir.file || { echo "Error: File not found or request failed"; exit 1; }
 
       - name: Clean up
         if: always()
         run: |
-          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/tests/short_range/VPU_${{ env.VPU }} || echo "No file to delete"
+          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/test/cicd/nrds/short_range/VPU_${{ env.VPU }} || echo "No file to delete"

--- a/.github/workflows/test_research_datastream_vpu_13.yaml
+++ b/.github/workflows/test_research_datastream_vpu_13.yaml
@@ -38,7 +38,7 @@ jobs:
           # Download the execution JSON
           aws s3 cp s3://ciroh-community-ngen-datastream/v2.2/ngen.${{ env.DATE }}/short_range/00/VPU_16/datastream-metadata/execution.json execution.json
           # Remove specified fields, update TagSpecifications, and modify S3 prefix in commands
-          jq --arg VPU "${{ env.VPU }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions"}]}] | .commands |= map(sub("--S3_PREFIX(?i) \\K[^ ]+"; "tests/short_range/VPU_\($VPU)'\''")) | .commands |= map(gsub("VPU_16"; "VPU_\($VPU)"))' execution.json > temp.json
+          jq --arg VPU "${{ env.VPU }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions"}]}] | .commands |= map(sub("--S3_PREFIX(?i) \\K[^ ]+"; "test/cicd/nrds/short_range/VPU_\($VPU)'\''")) | .commands |= map(gsub("VPU_16"; "VPU_\($VPU)"))' execution.json > temp.json
           
       - name: Check and create AWS key pair
         run: |
@@ -68,9 +68,9 @@ jobs:
 
       - name: Verify output file
         run: |
-          curl -fSs -o test.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/VPU_${{ env.VPU }}/merkdir.file || { echo "Error: File not found or request failed"; exit 1; }
+          curl -fSs -o test.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/VPU_${{ env.VPU }}/merkdir.file || { echo "Error: File not found or request failed"; exit 1; }
 
       - name: Clean up
         if: always()
         run: |
-          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/tests/short_range/VPU_${{ env.VPU }} || echo "No file to delete"
+          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/test/cicd/nrds/short_range/VPU_${{ env.VPU }} || echo "No file to delete"

--- a/.github/workflows/test_research_datastream_vpu_14.yaml
+++ b/.github/workflows/test_research_datastream_vpu_14.yaml
@@ -38,7 +38,7 @@ jobs:
           # Download the execution JSON
           aws s3 cp s3://ciroh-community-ngen-datastream/v2.2/ngen.${{ env.DATE }}/short_range/00/VPU_16/datastream-metadata/execution.json execution.json
           # Remove specified fields, update TagSpecifications, and modify S3 prefix in commands
-          jq --arg VPU "${{ env.VPU }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions"}]}] | .commands |= map(sub("--S3_PREFIX(?i) \\K[^ ]+"; "tests/short_range/VPU_\($VPU)'\''")) | .commands |= map(gsub("VPU_16"; "VPU_\($VPU)"))' execution.json > temp.json
+          jq --arg VPU "${{ env.VPU }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions"}]}] | .commands |= map(sub("--S3_PREFIX(?i) \\K[^ ]+"; "test/cicd/nrds/short_range/VPU_\($VPU)'\''")) | .commands |= map(gsub("VPU_16"; "VPU_\($VPU)"))' execution.json > temp.json
           
       - name: Check and create AWS key pair
         run: |
@@ -68,9 +68,9 @@ jobs:
 
       - name: Verify output file
         run: |
-          curl -fSs -o test.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/VPU_${{ env.VPU }}/merkdir.file || { echo "Error: File not found or request failed"; exit 1; }
+          curl -fSs -o test.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/VPU_${{ env.VPU }}/merkdir.file || { echo "Error: File not found or request failed"; exit 1; }
 
       - name: Clean up
         if: always()
         run: |
-          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/tests/short_range/VPU_${{ env.VPU }} || echo "No file to delete"
+          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/test/cicd/nrds/short_range/VPU_${{ env.VPU }} || echo "No file to delete"

--- a/.github/workflows/test_research_datastream_vpu_15.yaml
+++ b/.github/workflows/test_research_datastream_vpu_15.yaml
@@ -38,7 +38,7 @@ jobs:
           # Download the execution JSON
           aws s3 cp s3://ciroh-community-ngen-datastream/v2.2/ngen.${{ env.DATE }}/short_range/00/VPU_16/datastream-metadata/execution.json execution.json
           # Remove specified fields, update TagSpecifications, and modify S3 prefix in commands
-          jq --arg VPU "${{ env.VPU }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions"}]}] | .commands |= map(sub("--S3_PREFIX(?i) \\K[^ ]+"; "tests/short_range/VPU_\($VPU)'\''")) | .commands |= map(gsub("VPU_16"; "VPU_\($VPU)"))' execution.json > temp.json
+          jq --arg VPU "${{ env.VPU }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions"}]}] | .commands |= map(sub("--S3_PREFIX(?i) \\K[^ ]+"; "test/cicd/nrds/short_range/VPU_\($VPU)'\''")) | .commands |= map(gsub("VPU_16"; "VPU_\($VPU)"))' execution.json > temp.json
           
       - name: Check and create AWS key pair
         run: |
@@ -68,9 +68,9 @@ jobs:
 
       - name: Verify output file
         run: |
-          curl -fSs -o test.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/VPU_${{ env.VPU }}/merkdir.file || { echo "Error: File not found or request failed"; exit 1; }
+          curl -fSs -o test.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/VPU_${{ env.VPU }}/merkdir.file || { echo "Error: File not found or request failed"; exit 1; }
 
       - name: Clean up
         if: always()
         run: |
-          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/tests/short_range/VPU_${{ env.VPU }} || echo "No file to delete"
+          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/test/cicd/nrds/short_range/VPU_${{ env.VPU }} || echo "No file to delete"

--- a/.github/workflows/test_research_datastream_vpu_16.yaml
+++ b/.github/workflows/test_research_datastream_vpu_16.yaml
@@ -38,7 +38,7 @@ jobs:
           # Download the execution JSON
           aws s3 cp s3://ciroh-community-ngen-datastream/v2.2/ngen.${{ env.DATE }}/short_range/00/VPU_16/datastream-metadata/execution.json execution.json
           # Remove specified fields, update TagSpecifications, and modify S3 prefix in commands
-          jq --arg VPU "${{ env.VPU }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions"}]}] | .commands |= map(sub("--S3_PREFIX(?i) \\K[^ ]+"; "tests/short_range/VPU_\($VPU)'\''")) | .commands |= map(gsub("VPU_16"; "VPU_\($VPU)"))' execution.json > temp.json
+          jq --arg VPU "${{ env.VPU }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions"}]}] | .commands |= map(sub("--S3_PREFIX(?i) \\K[^ ]+"; "test/cicd/nrds/short_range/VPU_\($VPU)'\''")) | .commands |= map(gsub("VPU_16"; "VPU_\($VPU)"))' execution.json > temp.json
           
       - name: Check and create AWS key pair
         run: |
@@ -68,9 +68,9 @@ jobs:
 
       - name: Verify output file
         run: |
-          curl -fSs -o test.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/VPU_${{ env.VPU }}/merkdir.file || { echo "Error: File not found or request failed"; exit 1; }
+          curl -fSs -o test.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/VPU_${{ env.VPU }}/merkdir.file || { echo "Error: File not found or request failed"; exit 1; }
 
       - name: Clean up
         if: always()
         run: |
-          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/tests/short_range/VPU_${{ env.VPU }} || echo "No file to delete"
+          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/test/cicd/nrds/short_range/VPU_${{ env.VPU }} || echo "No file to delete"

--- a/.github/workflows/test_research_datastream_vpu_17.yaml
+++ b/.github/workflows/test_research_datastream_vpu_17.yaml
@@ -38,7 +38,7 @@ jobs:
           # Download the execution JSON
           aws s3 cp s3://ciroh-community-ngen-datastream/v2.2/ngen.${{ env.DATE }}/short_range/00/VPU_16/datastream-metadata/execution.json execution.json
           # Remove specified fields, update TagSpecifications, and modify S3 prefix in commands
-          jq --arg VPU "${{ env.VPU }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions"}]}] | .commands |= map(sub("--S3_PREFIX(?i) \\K[^ ]+"; "tests/short_range/VPU_\($VPU)'\''")) | .commands |= map(gsub("VPU_16"; "VPU_\($VPU)"))' execution.json > temp.json
+          jq --arg VPU "${{ env.VPU }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions"}]}] | .commands |= map(sub("--S3_PREFIX(?i) \\K[^ ]+"; "test/cicd/nrds/short_range/VPU_\($VPU)'\''")) | .commands |= map(gsub("VPU_16"; "VPU_\($VPU)"))' execution.json > temp.json
           
       - name: Check and create AWS key pair
         run: |
@@ -68,9 +68,9 @@ jobs:
 
       - name: Verify output file
         run: |
-          curl -fSs -o test.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/VPU_${{ env.VPU }}/merkdir.file || { echo "Error: File not found or request failed"; exit 1; }
+          curl -fSs -o test.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/VPU_${{ env.VPU }}/merkdir.file || { echo "Error: File not found or request failed"; exit 1; }
 
       - name: Clean up
         if: always()
         run: |
-          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/tests/short_range/VPU_${{ env.VPU }} || echo "No file to delete"
+          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/test/cicd/nrds/short_range/VPU_${{ env.VPU }} || echo "No file to delete"

--- a/.github/workflows/test_research_datastream_vpu_18.yaml
+++ b/.github/workflows/test_research_datastream_vpu_18.yaml
@@ -38,7 +38,7 @@ jobs:
           # Download the execution JSON
           aws s3 cp s3://ciroh-community-ngen-datastream/v2.2/ngen.${{ env.DATE }}/short_range/00/VPU_16/datastream-metadata/execution.json execution.json
           # Remove specified fields, update TagSpecifications, and modify S3 prefix in commands
-          jq --arg VPU "${{ env.VPU }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions"}]}] | .commands |= map(sub("--S3_PREFIX(?i) \\K[^ ]+"; "tests/short_range/VPU_\($VPU)'\''")) | .commands |= map(gsub("VPU_16"; "VPU_\($VPU)"))' execution.json > temp.json
+          jq --arg VPU "${{ env.VPU }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions"}]}] | .commands |= map(sub("--S3_PREFIX(?i) \\K[^ ]+"; "test/cicd/nrds/short_range/VPU_\($VPU)'\''")) | .commands |= map(gsub("VPU_16"; "VPU_\($VPU)"))' execution.json > temp.json
           
       - name: Check and create AWS key pair
         run: |
@@ -68,9 +68,9 @@ jobs:
 
       - name: Verify output file
         run: |
-          curl -fSs -o test.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/VPU_${{ env.VPU }}/merkdir.file || { echo "Error: File not found or request failed"; exit 1; }
+          curl -fSs -o test.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/VPU_${{ env.VPU }}/merkdir.file || { echo "Error: File not found or request failed"; exit 1; }
 
       - name: Clean up
         if: always()
         run: |
-          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/tests/short_range/VPU_${{ env.VPU }} || echo "No file to delete"
+          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/test/cicd/nrds/short_range/VPU_${{ env.VPU }} || echo "No file to delete"

--- a/.github/workflows/test_vpu_short_medium.yaml
+++ b/.github/workflows/test_vpu_short_medium.yaml
@@ -48,7 +48,7 @@ jobs:
         run: |
           cd research_datastream/terraform_community
           short_range_fp_execution_file="test_executions/short_range/00/execution_datastream_fp.json"
-          jq --arg DATE "${{ env.DATE }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions"}]}] | .commands |= map(sub("--s3_prefix(?i) \\K[^ ]+"; "tests/short_range/fp'\''")) | .commands |= map(gsub("--start_date DAILY"; "--start_date DAILY --end_date \($DATE)0000"))' short_range_fp_execution_file.json > temp.json
+          jq --arg DATE "${{ env.DATE }}" 'del(.instance_parameters.MaxCount, .instance_parameters.MinCount, .instance_parameters.InstanceId, .t0, .ii_s3_object_checked, .retry_attempt, .region) | .instance_parameters.TagSpecifications = [{"ResourceType": "instance", "Tags": [{"Key": "Project", "Value": "fp_test_git_actions"}]}] | .commands |= map(sub("--s3_prefix(?i) \\K[^ ]+"; "test/cicd/nrds/short_range/fp'\''")) | .commands |= map(gsub("--start_date DAILY"; "--start_date DAILY --end_date \($DATE)0000"))' short_range_fp_execution_file.json > temp.json
 
 
       - name: Check and create AWS key pair
@@ -80,37 +80,37 @@ jobs:
 
       - name: Verify output files
         run: |
-          curl -fSs -o test_01.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_01.nc || { echo "Error: VPU_01 not found"; exit 1; }
-          curl -fSs -o test_02.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_02.nc || { echo "Error: VPU_02 not found"; exit 1; }
-          curl -fSs -o test_03W.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_03W.nc || { echo "Error: VPU_03W not found"; exit 1; }
-          curl -fSs -o test_03S.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_03S.nc || { echo "Error: VPU_03S not found"; exit 1; }
-          curl -fSs -o test_03N.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_03N.nc || { echo "Error: VPU_03N not found"; exit 1; }
-          curl -fSs -o test_04.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_04.nc || { echo "Error: VPU_04 not found"; exit 1; }
-          curl -fSs -o test_05.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_05.nc || { echo "Error: VPU_05 not found"; exit 1; }
-          curl -fSs -o test_06.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_06.nc || { echo "Error: VPU_06 not found"; exit 1; }
-          curl -fSs -o test_07.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_07.nc || { echo "Error: VPU_07 not found"; exit 1; }
-          curl -fSs -o test_08.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_08.nc || { echo "Error: VPU_08 not found"; exit 1; }
-          curl -fSs -o test_09.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_09.nc || { echo "Error: VPU_09 not found"; exit 1; }
-          curl -fSs -o test_10L.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_10L.nc || { echo "Error: VPU_10L not found"; exit 1; }
-          curl -fSs -o test_10U.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_10U.nc || { echo "Error: VPU_10U not found"; exit 1; }
-          curl -fSs -o test_11.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_11.nc || { echo "Error: VPU_11 not found"; exit 1; }
-          curl -fSs -o test_12.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_12.nc || { echo "Error: VPU_12 not found"; exit 1; }
-          curl -fSs -o test_13.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_13.nc || { echo "Error: VPU_13 not found"; exit 1; }
-          curl -fSs -o test_14.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_14.nc || { echo "Error: VPU_14 not found"; exit 1; }
-          curl -fSs -o test_15.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_15.nc || { echo "Error: VPU_15 not found"; exit 1; }
-          curl -fSs -o test_16.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_16.nc || { echo "Error: VPU_16 not found"; exit 1; }
-          curl -fSs -o test_17.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_17.nc || { echo "Error: VPU_17 not found"; exit 1; }
-          curl -fSs -o test_18.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_18.nc || { echo "Error: VPU_18 not found"; exit 1; }
+          curl -fSs -o test_01.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_01.nc || { echo "Error: VPU_01 not found"; exit 1; }
+          curl -fSs -o test_02.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_02.nc || { echo "Error: VPU_02 not found"; exit 1; }
+          curl -fSs -o test_03W.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_03W.nc || { echo "Error: VPU_03W not found"; exit 1; }
+          curl -fSs -o test_03S.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_03S.nc || { echo "Error: VPU_03S not found"; exit 1; }
+          curl -fSs -o test_03N.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_03N.nc || { echo "Error: VPU_03N not found"; exit 1; }
+          curl -fSs -o test_04.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_04.nc || { echo "Error: VPU_04 not found"; exit 1; }
+          curl -fSs -o test_05.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_05.nc || { echo "Error: VPU_05 not found"; exit 1; }
+          curl -fSs -o test_06.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_06.nc || { echo "Error: VPU_06 not found"; exit 1; }
+          curl -fSs -o test_07.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_07.nc || { echo "Error: VPU_07 not found"; exit 1; }
+          curl -fSs -o test_08.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_08.nc || { echo "Error: VPU_08 not found"; exit 1; }
+          curl -fSs -o test_09.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_09.nc || { echo "Error: VPU_09 not found"; exit 1; }
+          curl -fSs -o test_10L.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_10L.nc || { echo "Error: VPU_10L not found"; exit 1; }
+          curl -fSs -o test_10U.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_10U.nc || { echo "Error: VPU_10U not found"; exit 1; }
+          curl -fSs -o test_11.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_11.nc || { echo "Error: VPU_11 not found"; exit 1; }
+          curl -fSs -o test_12.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_12.nc || { echo "Error: VPU_12 not found"; exit 1; }
+          curl -fSs -o test_13.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_13.nc || { echo "Error: VPU_13 not found"; exit 1; }
+          curl -fSs -o test_14.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_14.nc || { echo "Error: VPU_14 not found"; exit 1; }
+          curl -fSs -o test_15.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_15.nc || { echo "Error: VPU_15 not found"; exit 1; }
+          curl -fSs -o test_16.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_16.nc || { echo "Error: VPU_16 not found"; exit 1; }
+          curl -fSs -o test_17.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_17.nc || { echo "Error: VPU_17 not found"; exit 1; }
+          curl -fSs -o test_18.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/fp/ngen.t00z.short_range.forcing.f001_f018.VPU_18.nc || { echo "Error: VPU_18 not found"; exit 1; }
 
       - name: Debug - Check what files were created
         run: |
           echo "Checking what files were actually created..."
-          aws s3 ls s3://ciroh-community-ngen-datastream/tests/ --recursive
+          aws s3 ls s3://ciroh-community-ngen-datastream/test/cicd/nrds/ --recursive
 
       - name: Verify output files
         run: |
           echo "Checking if processing created any output files for FP..."
-          file_list=$(aws s3 ls s3://ciroh-community-ngen-datastream/tests/short_range/fp/ --recursive 2>/dev/null || echo "")
+          file_list=$(aws s3 ls s3://ciroh-community-ngen-datastream/test/cicd/nrds/short_range/fp/ --recursive 2>/dev/null || echo "")
           
           if [ -n "$file_list" ]; then
             echo "SUCCESS: FP processing completed successfully!"
@@ -124,7 +124,7 @@ jobs:
       - name: Clean up
         if: always()
         run: |
-          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/tests/short_range/fp || echo "No file to delete"
+          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/test/cicd/nrds/short_range/fp || echo "No file to delete"
 
 
   test-all-vpus:
@@ -186,7 +186,7 @@ jobs:
             }] |
             .commands |= map(
                 # swap placeholder only; no regex near quotes
-                gsub("__S3_PREFIX__"; "tests/short_range/VPU_\($VPU)")
+                gsub("__S3_PREFIX__"; "test/cicd/nrds/short_range/VPU_\($VPU)")
               | gsub("ngen.DAILY"; "ngen.\($DATE)")
               | gsub("-s DAILY"; "-s DAILY -e \($DATE)0000")
             )
@@ -211,7 +211,7 @@ jobs:
               ]
             }] |
             .commands |= map(
-                gsub("__S3_PREFIX__"; "tests/medium_range/VPU_\($VPU)")
+                gsub("__S3_PREFIX__"; "test/cicd/nrds/medium_range/VPU_\($VPU)")
               | gsub("ngen.DAILY"; "ngen.\($DATE)")
               | gsub("-s DAILY"; "-s DAILY -e \($DATE)0000")
             )
@@ -264,7 +264,7 @@ jobs:
         run: |
           echo "Checking if processing created output files for VPU ${{ env.VPU }}..."
           
-          file_list=$(aws s3 ls s3://ciroh-community-ngen-datastream/tests/short_range/VPU_${{ env.VPU }}/ --recursive 2>/dev/null || echo "")
+          file_list=$(aws s3 ls s3://ciroh-community-ngen-datastream/test/cicd/nrds/short_range/VPU_${{ env.VPU }}/ --recursive 2>/dev/null || echo "")
           
           if [ -n "$file_list" ]; then
             echo "SUCCESS: VPU ${{ env.VPU }} processing completed!"
@@ -279,7 +279,7 @@ jobs:
       - name: Verify specific file (Short Range)
         if: matrix.vpu != '10U' && matrix.vpu != '17'
         run: |
-          curl -fSs -o test.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/VPU_${{ env.VPU }}/merkdir.file || { 
+          curl -fSs -o test.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/VPU_${{ env.VPU }}/merkdir.file || { 
             echo "Error: File not found or request failed"; exit 1; 
           } 
 
@@ -319,7 +319,7 @@ jobs:
         if: matrix.vpu != '10U' && matrix.vpu != '17'
         run: |
           echo "Checking if processing created output files for VPU ${{ env.VPU }}..."
-          file_list=$(aws s3 ls s3://ciroh-community-ngen-datastream/tests/medium_range/VPU_${{ env.VPU }}/ --recursive 2>/dev/null || echo "")
+          file_list=$(aws s3 ls s3://ciroh-community-ngen-datastream/test/cicd/nrds/medium_range/VPU_${{ env.VPU }}/ --recursive 2>/dev/null || echo "")
           
           if [ -n "$file_list" ]; then
             echo "SUCCESS: VPU ${{ env.VPU }} processing completed!"
@@ -334,15 +334,15 @@ jobs:
       - name: Verify specific file (Medium Range)
         if: matrix.vpu != '10U' && matrix.vpu != '17'
         run: |
-          curl -fSs -o test.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/tests/short_range/VPU_${{ env.VPU }}/merkdir.file || { 
+          curl -fSs -o test.txt https://ciroh-community-ngen-datastream.s3.amazonaws.com/test/cicd/nrds/short_range/VPU_${{ env.VPU }}/merkdir.file || { 
             echo "Error: File not found or request failed"; exit 1; 
           } 
           
       - name: Clean up
         if: always()
         run: |
-          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/tests/short_range/VPU_${{ env.VPU }} || echo "No files to delete"
-          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/tests/medium_range/VPU_${{ env.VPU }} || echo "No files to delete"
+          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/test/cicd/nrds/short_range/VPU_${{ env.VPU }} || echo "No files to delete"
+          aws s3 rm --recursive s3://ciroh-community-ngen-datastream/test/cicd/nrds/medium_range/VPU_${{ env.VPU }} || echo "No files to delete"
 
 
 

--- a/infra/aws/terraform/examples/execution_nrds.json
+++ b/infra/aws/terraform/examples/execution_nrds.json
@@ -1,13 +1,13 @@
 {
   "commands": [
-    "runuser -l ec2-user -c 'export SKIP_VALIDATION=True FP_TAG=1.0.3 DS_TAG=1.0.2 NGIAB_TAG=1.5.0 && /home/ec2-user/ngen-datastream/scripts/datastream -s DAILY -n 3 -F s3://ciroh-community-ngen-datastream/v2.2/ngen.DAILY/forcing_short_range/00/ngen.t00z.short_range.forcing.f001_f018.VPU_01.nc --FORCING_SOURCE NWM_V3_SHORT_RANGE_00 -d /home/ec2-user/outputs -r s3://ciroh-community-ngen-datastream/v2.2_resources/VPU_01 -R https://ciroh-community-ngen-datastream.s3.amazonaws.com/realizations/realization_VPU_01.json --S3_BUCKET ciroh-community-ngen-datastream --S3_PREFIX tests/orca_test'"
+    "runuser -l ec2-user -c 'export SKIP_VALIDATION=True FP_TAG=1.0.3 DS_TAG=1.0.2 NGIAB_TAG=1.5.0 && /home/ec2-user/ngen-datastream/scripts/datastream -s DAILY -n 3 -F s3://ciroh-community-ngen-datastream/v2.2/ngen.DAILY/forcing_short_range/00/ngen.t00z.short_range.forcing.f001_f018.VPU_01.nc --FORCING_SOURCE NWM_V3_SHORT_RANGE_00 -d /home/ec2-user/outputs -r s3://ciroh-community-ngen-datastream/v2.2_resources/VPU_01 -R https://ciroh-community-ngen-datastream.s3.amazonaws.com/realizations/realization_VPU_01.json --S3_BUCKET ciroh-community-ngen-datastream --S3_PREFIX test/cicd/nrds/orca_test'"
   ],
   "run_options": {
     "ii_terminate_instance": true,
     "ii_delete_volume": true,
     "ii_check_s3": {
       "bucket": "ciroh-community-ngen-datastream",
-      "prefix": "tests/orca_test/ngen-run.tar.gz"
+      "prefix": "test/cicd/nrds/orca_test/ngen-run.tar.gz"
     },
     "ii_cheapo": true,
     "timeout_s": 3600,

--- a/infra/aws/terraform/modules/orchestration/lambdas/checker/lambda_function.py
+++ b/infra/aws/terraform/modules/orchestration/lambdas/checker/lambda_function.py
@@ -66,7 +66,7 @@ def lambda_handler(event, context):
 def store_failed_execution(execution,bucket):
     print(f'Execution failed, storing execution in {bucket}')
     timestamp = datetime.datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')
-    key = f"tests/failed_executions/{timestamp}.json"
+    key = f"test/cicd/nrds/failed_executions/{timestamp}.json"
     client_s3.put_object(Bucket=bucket, Key=key, Body=json.dumps(execution))
     print(f'Execution stored in {bucket} at {key}')
 


### PR DESCRIPTION
## Summary
- Consolidate all CI/CD test S3 writes from scattered `tests/` prefixes to a unified `test/cicd/nrds/` structure
- Updated 27 files (21 VPU workflows, 4 composite/build workflows, checker lambda, example execution JSON)
- No functional changes — only S3 prefix string literal updates

### Prefix mapping
| Old | New |
|-----|-----|
| `tests/short_range/VPU_XX` | `test/cicd/nrds/short_range/VPU_XX` |
| `tests/short_range/fp` | `test/cicd/nrds/short_range/fp` |
| `tests/medium_range/VPU_XX` | `test/cicd/nrds/medium_range/VPU_XX` |
| `tests/failed_executions/` | `test/cicd/nrds/failed_executions/` |
| `tests/orca_test` | `test/cicd/nrds/orca_test` |

Solves https://github.com/CIROH-UA/ngen-datastream/issues/301 WRT ngen-datastream
