### PR TITLE
Add Secrets Manager access to EC2 policy for Docker Hub login

### DIFF
--- a/infra/aws/terraform/modules/orchestration/iam_ec2.tf
+++ b/infra/aws/terraform/modules/orchestration/iam_ec2.tf
@@ -56,6 +56,13 @@ resource "aws_iam_policy" "ec2_policy" {
           "ec2:DescribeTags"
         ],
         Resource = "*"
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "secretsmanager:GetSecretValue"
+        ],
+        Resource = "arn:aws:secretsmanager:us-east-1:879381264451:secret:docker_awiciroh_creds-*"
       }
     ]
   })


### PR DESCRIPTION
## Summary
- Adds `secretsmanager:GetSecretValue` permission to the EC2 IAM policy
- Scoped to `docker_awiciroh_creds` secret only
- Required for EC2 instances to retrieve Docker Hub credentials during image push via `docker_loginNpush.sh`

## Context
ARM Docker build/push workflows fail at the push step because EC2 instances cannot call `aws secretsmanager get-secret-value` to retrieve Docker Hub credentials. This was the root cause of push failures across all instance profiles.

## Test plan
- [ ] `terraform plan` shows only the policy update
- [ ] Re-run ARM Docker push workflow and verify Docker login succeeds