### PR TITLE
Add cfe-nom datastream module

### DIFF
--- a/infra/aws/terraform/README.md
+++ b/infra/aws/terraform/README.md
@@ -16,6 +16,10 @@ infra/aws/terraform/
       prod.backend.hcl            # S3 backend config
       prod.tfvars                 # Production variable values
     datastreams/
+      cfe-nom/                    # CFE NOM schedule module
+        schedules.tf              # Short range, medium range, AnA schedules
+        config/                   # Forecast input configuration
+        templates/                # Execution JSON templates
       routing-only/               # Routing-Only schedule module
         schedules.tf              # Short range schedules
         config/

--- a/infra/aws/terraform/services/nrds/datastreams/cfe-nom/config/execution_forecast_inputs_cfe_nom.json
+++ b/infra/aws/terraform/services/nrds/datastreams/cfe-nom/config/execution_forecast_inputs_cfe_nom.json
@@ -1,0 +1,89 @@
+{
+  "short_range": {
+    "init_cycles": [
+      "00", "01", "02", "03", "04", "05",
+      "06", "07", "08", "09", "10", "11",
+      "12", "13", "14", "15", "16", "17",
+      "18", "19", "20", "21", "22", "23"
+    ],
+    "instance_types": {
+      "01": "m8g.xlarge",
+      "02": "m8g.xlarge",
+      "03N": "m8g.xlarge",
+      "03S": "m8g.xlarge",
+      "03W": "m8g.xlarge",
+      "04": "m8g.xlarge",
+      "05": "m8g.2xlarge",
+      "06": "m8g.xlarge",
+      "07": "m8g.2xlarge",
+      "08": "m8g.xlarge",
+      "09": "m8g.xlarge",
+      "10L": "m8g.2xlarge",
+      "10U": "m8g.2xlarge",
+      "11": "m8g.2xlarge",
+      "12": "m8g.xlarge",
+      "13": "m8g.xlarge",
+      "14": "m8g.xlarge",
+      "15": "m8g.xlarge",
+      "16": "m8g.xlarge",
+      "18": "m8g.xlarge",
+      "fp": "m8g.2xlarge"
+    },
+    "volume_size": 64
+  },
+  "medium_range": {
+    "init_cycles": ["00", "06", "12", "18"],
+    "ensemble_members": ["1"],
+    "instance_types": {
+      "01": "m8g.2xlarge",
+      "02": "m8g.2xlarge",
+      "03W": "m8g.2xlarge",
+      "03N": "m8g.2xlarge",
+      "03S": "m8g.2xlarge",
+      "04": "m8g.2xlarge",
+      "05": "m8g.2xlarge",
+      "06": "m8g.2xlarge",
+      "07": "m8g.2xlarge",
+      "08": "m8g.2xlarge",
+      "09": "m8g.2xlarge",
+      "10L": "m8g.4xlarge",
+      "10U": "m8g.4xlarge",
+      "11": "m8g.2xlarge",
+      "12": "m8g.2xlarge",
+      "13": "m8g.2xlarge",
+      "14": "m8g.2xlarge",
+      "15": "m8g.2xlarge",
+      "16": "m8g.2xlarge",
+      "18": "m8g.2xlarge",
+      "fp": "m8g.4xlarge"
+    },
+    "volume_size": 64
+  },
+  "analysis_assim_extend": {
+    "init_cycles": ["16"],
+    "instance_types": {
+      "01": "m8g.xlarge",
+      "02": "m8g.xlarge",
+      "03N": "m8g.xlarge",
+      "03S": "m8g.xlarge",
+      "03W": "m8g.xlarge",
+      "04": "m8g.xlarge",
+      "05": "m8g.2xlarge",
+      "06": "m8g.xlarge",
+      "07": "m8g.2xlarge",
+      "08": "m8g.xlarge",
+      "09": "m8g.xlarge",
+      "10L": "m8g.2xlarge",
+      "10U": "m8g.2xlarge",
+      "11": "m8g.2xlarge",
+      "12": "m8g.xlarge",
+      "13": "m8g.xlarge",
+      "14": "m8g.xlarge",
+      "15": "m8g.xlarge",
+      "16": "m8g.xlarge",
+      "18": "m8g.xlarge",
+      "fp": "m8g.2xlarge"
+    },
+    "volume_size": 64
+  }
+}

--- a/infra/aws/terraform/services/nrds/datastreams/cfe-nom/main.tf
+++ b/infra/aws/terraform/services/nrds/datastreams/cfe-nom/main.tf
@@ -1,0 +1,63 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+locals {
+  vpus = [
+    "fp", "01", "02", "03N", "03S", "03W", "04",
+    "05", "06", "07", "08", "09", "10L",
+    "10U", "11", "12", "13", "14", "15",
+    "16", "18"
+  ]
+}
+
+variable "region" {}
+
+variable "scheduler_role_arn" {
+  type        = string
+  description = "ARN of the shared scheduler IAM role"
+}
+
+variable "state_machine_arn" {
+  type = string
+}
+
+variable "ec2_instance_profile" {
+  type        = string
+  description = "IAM instance profile name for EC2"
+}
+
+variable "cfe_nom_ami_id" {
+  type        = string
+  description = "AMI ID for CFE_NOM model EC2 instances"
+}
+
+variable "fp_ami_id" {
+  type        = string
+  description = "AMI ID for forcing processor EC2 instances"
+}
+
+variable "schedule_timezone" {
+  type    = string
+  default = "America/New_York"
+}
+
+variable "schedule_group_name" {
+  type    = string
+  default = "default"
+}
+
+variable "environment_suffix" {
+  type = string
+}
+
+variable "s3_bucket" {
+  type    = string
+  default = "ciroh-community-ngen-datastream"
+}

--- a/infra/aws/terraform/services/nrds/datastreams/cfe-nom/outputs.tf
+++ b/infra/aws/terraform/services/nrds/datastreams/cfe-nom/outputs.tf
@@ -1,0 +1,11 @@
+output "short_range_schedule_count" {
+  value = length(aws_scheduler_schedule.datastream_schedule_short_range_cfe_nom)
+}
+
+output "medium_range_schedule_count" {
+  value = length(aws_scheduler_schedule.datastream_schedule_medium_range_cfe_nom)
+}
+
+output "analysis_assim_schedule_count" {
+  value = length(aws_scheduler_schedule.datastream_schedule_AnA_range_cfe_nom)
+}

--- a/infra/aws/terraform/services/nrds/datastreams/cfe-nom/schedules.tf
+++ b/infra/aws/terraform/services/nrds/datastreams/cfe-nom/schedules.tf
@@ -1,0 +1,307 @@
+locals {
+  instance_vcpus = {
+    "m8g.xlarge"  = 4
+    "m8g.2xlarge" = 8
+    "m8g.4xlarge" = 16
+  }
+
+  init_cycles_config_cfe_nom = jsondecode(file("${path.module}/config/execution_forecast_inputs_cfe_nom.json"))
+
+  cfe_nom_template_path = "${path.module}/templates/execution_datastream_cfe_nom_VPU_template.json.tpl"
+
+  cfe_nom_ami_id           = var.cfe_nom_ami_id
+  cfe_nom_instance_profile = var.ec2_instance_profile
+
+  fp_template_path    = "${path.module}/templates/execution_datastream_cfe_nom_fp_template.json.tpl"
+  fp_ami_id           = var.fp_ami_id
+  fp_instance_profile = var.ec2_instance_profile
+  fp_vpu_list         = join(",", [for v in local.vpus : v if v != "fp"])
+
+  short_range_cfe_nom_config = {
+    for pair in flatten([
+      for init in local.init_cycles_config_cfe_nom.short_range.init_cycles : [
+        for vpu in local.vpus : {
+          key           = "${init}_${vpu}"
+          init          = init
+          vpu           = vpu
+          instance_type = local.init_cycles_config_cfe_nom.short_range.instance_types[vpu]
+          volume_size   = local.init_cycles_config_cfe_nom.short_range.volume_size
+          run_type_l    = "short_range"
+          run_type_h    = "SHORT_RANGE"
+          fcst          = "f001_f018"
+          member        = ""
+          member_suffix = ""
+          member_path   = ""
+          nprocs        = local.instance_vcpus[local.init_cycles_config_cfe_nom.short_range.instance_types[vpu]] - 1
+        }
+      ]
+    ]) : pair.key => pair
+  }
+
+  short_range_times_cfe_nom = {
+    for pair in flatten([
+      for init in local.init_cycles_config_cfe_nom.short_range.init_cycles : [
+        for vpu in local.vpus : {
+          key   = "${init}_${vpu}"
+          value = vpu == "fp" ? (tonumber(init)) % 24 : (tonumber(init) + 1) % 24
+        }
+      ]
+    ]) : pair.key => pair.value
+  }
+
+  medium_range_cfe_nom_config = {
+    for pair in flatten([
+      for init in local.init_cycles_config_cfe_nom.medium_range.init_cycles : [
+        for vpu in local.vpus : [
+          for member in(
+            vpu == "fp" ? ["1"] : local.init_cycles_config_cfe_nom.medium_range.ensemble_members
+            ) : {
+            key           = "${init}_${member}_${vpu}"
+            init          = init
+            vpu           = vpu
+            instance_type = local.init_cycles_config_cfe_nom.medium_range.instance_types[vpu]
+            volume_size   = local.init_cycles_config_cfe_nom.medium_range.volume_size
+            run_type_l    = "medium_range"
+            run_type_h    = "MEDIUM_RANGE"
+            fcst          = "f001_f240"
+            member        = member
+            member_suffix = vpu == "fp" ? "_0" : "_${member}"
+            member_path   = "/${member}"
+            nprocs        = local.instance_vcpus[local.init_cycles_config_cfe_nom.medium_range.instance_types[vpu]] - 1
+          }
+        ]
+      ]
+    ]) : pair.key => pair
+  }
+
+  medium_range_times_cfe_nom = {
+    for pair in flatten([
+      for init in local.init_cycles_config_cfe_nom.medium_range.init_cycles : [
+        for vpu in local.vpus : [
+          for member in(
+            vpu == "fp" ? ["1"] : local.init_cycles_config_cfe_nom.medium_range.ensemble_members
+            ) : {
+            key   = "${init}_${member}_${vpu}"
+            value = vpu == "fp" ? (tonumber(init) + 2) % 24 : (tonumber(init) + 3) % 24
+          }
+        ]
+      ]
+    ]) : pair.key => pair.value
+  }
+
+  medium_range_member_offsets_cfe_nom = {
+    for pair in flatten([
+      for init in local.init_cycles_config_cfe_nom.medium_range.init_cycles : [
+        for member in local.init_cycles_config_cfe_nom.medium_range.ensemble_members : [
+          for vpu in local.vpus : {
+            key   = "${init}_${member}_${vpu}"
+            value = floor(((tonumber(member) - 1) * (1.0 / 7.0) * 60) % 60)
+          }
+        ]
+      ]
+    ]) : pair.key => pair.value
+  }
+
+  analysis_assim_extend_cfe_nom_config = {
+    for pair in flatten([
+      for init in local.init_cycles_config_cfe_nom.analysis_assim_extend.init_cycles : [
+        for vpu in local.vpus : {
+          key           = "${init}_${vpu}"
+          init          = init
+          vpu           = vpu
+          instance_type = local.init_cycles_config_cfe_nom.analysis_assim_extend.instance_types[vpu]
+          volume_size   = local.init_cycles_config_cfe_nom.analysis_assim_extend.volume_size
+          run_type_l    = "analysis_assim_extend"
+          run_type_h    = "ANALYSIS_ASSIM_EXTEND"
+          fcst          = "tm27_tm00"
+          member        = ""
+          member_suffix = ""
+          member_path   = ""
+          nprocs        = local.instance_vcpus[local.init_cycles_config_cfe_nom.analysis_assim_extend.instance_types[vpu]] - 1
+        }
+      ]
+    ]) : pair.key => pair
+  }
+
+  analysis_assim_extend_times_cfe_nom = {
+    for pair in flatten([
+      for init in local.init_cycles_config_cfe_nom.analysis_assim_extend.init_cycles : [
+        for vpu in local.vpus : {
+          key   = "${init}_${vpu}"
+          value = vpu == "fp" ? 15 : 16
+        }
+      ]
+    ]) : pair.key => pair.value
+  }
+}
+
+# Short Range CFE_NOM Schedules
+resource "aws_scheduler_schedule" "datastream_schedule_short_range_cfe_nom" {
+  for_each = local.short_range_cfe_nom_config
+
+  name       = "short_range_fcst${each.value.init}_vpu${each.value.vpu}_schedule_cfe_nom_${var.environment_suffix}"
+  group_name = var.schedule_group_name
+
+  flexible_time_window {
+    mode = "OFF"
+  }
+
+  schedule_expression          = "cron(0 ${local.short_range_times_cfe_nom[each.key]} * * ? *)"
+  schedule_expression_timezone = var.schedule_timezone
+
+  target {
+    arn      = "arn:aws:scheduler:::aws-sdk:sfn:startExecution"
+    role_arn = var.scheduler_role_arn
+    input = <<-EOT
+{
+  "StateMachineArn": "${var.state_machine_arn}",
+  "Name": "cfe_nom_short_range_vpu${each.value.vpu}_init${each.value.init}_<aws.scheduler.execution-id>",
+  "Input": ${each.value.vpu == "fp" ? jsonencode(templatefile(local.fp_template_path, {
+    init               = each.value.init
+    run_type_l         = each.value.run_type_l
+    run_type_h         = each.value.run_type_h
+    member_suffix      = each.value.member_suffix
+    ami_id             = local.fp_ami_id
+    instance_type      = each.value.instance_type
+    instance_profile   = local.fp_instance_profile
+    volume_size        = each.value.volume_size
+    timeout_s          = 3600
+    environment_suffix = var.environment_suffix
+    s3_bucket          = var.s3_bucket
+    vpu_list           = local.fp_vpu_list
+    })) : jsonencode(templatefile(local.cfe_nom_template_path, {
+    vpu                = each.value.vpu
+    init               = each.value.init
+    run_type_l         = each.value.run_type_l
+    run_type_h         = each.value.run_type_h
+    fcst               = each.value.fcst
+    member             = each.value.member
+    member_suffix      = each.value.member_suffix
+    member_path        = each.value.member_path
+    nprocs             = each.value.nprocs
+    ami_id             = local.cfe_nom_ami_id
+    instance_type      = each.value.instance_type
+    instance_profile   = local.cfe_nom_instance_profile
+    volume_size        = each.value.volume_size
+    timeout_s          = 3600
+    environment_suffix = var.environment_suffix
+    s3_bucket          = var.s3_bucket
+}))}
+}
+EOT
+}
+}
+
+# Medium Range CFE_NOM Schedules
+resource "aws_scheduler_schedule" "datastream_schedule_medium_range_cfe_nom" {
+  for_each = local.medium_range_cfe_nom_config
+
+  name       = "medium_range_fcst${each.value.init}_mem${each.value.member}_vpu${each.value.vpu}_schedule_cfe_nom_${var.environment_suffix}"
+  group_name = var.schedule_group_name
+
+  flexible_time_window {
+    mode = "OFF"
+  }
+
+  schedule_expression          = "cron(${local.medium_range_member_offsets_cfe_nom[each.key]} ${local.medium_range_times_cfe_nom[each.key]} * * ? *)"
+  schedule_expression_timezone = var.schedule_timezone
+
+  target {
+    arn      = "arn:aws:scheduler:::aws-sdk:sfn:startExecution"
+    role_arn = var.scheduler_role_arn
+    input = <<-EOT
+{
+  "StateMachineArn": "${var.state_machine_arn}",
+  "Name": "cfe_nom_medium_range_vpu${each.value.vpu}_init${each.value.init}_mem${each.value.member}_<aws.scheduler.execution-id>",
+  "Input": ${each.value.vpu == "fp" ? jsonencode(templatefile(local.fp_template_path, {
+    init               = each.value.init
+    run_type_l         = each.value.run_type_l
+    run_type_h         = each.value.run_type_h
+    member_suffix      = each.value.member_suffix
+    ami_id             = local.fp_ami_id
+    instance_type      = each.value.instance_type
+    instance_profile   = local.fp_instance_profile
+    volume_size        = each.value.volume_size
+    timeout_s          = 7200
+    environment_suffix = var.environment_suffix
+    s3_bucket          = var.s3_bucket
+    vpu_list           = local.fp_vpu_list
+    })) : jsonencode(templatefile(local.cfe_nom_template_path, {
+    vpu                = each.value.vpu
+    init               = each.value.init
+    run_type_l         = each.value.run_type_l
+    run_type_h         = each.value.run_type_h
+    fcst               = each.value.fcst
+    member             = each.value.member
+    member_suffix      = each.value.member_suffix
+    member_path        = each.value.member_path
+    nprocs             = each.value.nprocs
+    ami_id             = local.cfe_nom_ami_id
+    instance_type      = each.value.instance_type
+    instance_profile   = local.cfe_nom_instance_profile
+    volume_size        = each.value.volume_size
+    timeout_s          = 7200
+    environment_suffix = var.environment_suffix
+    s3_bucket          = var.s3_bucket
+}))}
+}
+EOT
+}
+}
+
+# Analysis/Assimilation CFE_NOM Schedules
+resource "aws_scheduler_schedule" "datastream_schedule_AnA_range_cfe_nom" {
+  for_each = local.analysis_assim_extend_cfe_nom_config
+
+  name       = "analysis_assim_extend_fcst${each.value.init}_vpu${each.value.vpu}_schedule_cfe_nom_${var.environment_suffix}"
+  group_name = var.schedule_group_name
+
+  flexible_time_window {
+    mode = "OFF"
+  }
+
+  schedule_expression          = "cron(0 ${local.analysis_assim_extend_times_cfe_nom[each.key]} * * ? *)"
+  schedule_expression_timezone = var.schedule_timezone
+
+  target {
+    arn      = "arn:aws:scheduler:::aws-sdk:sfn:startExecution"
+    role_arn = var.scheduler_role_arn
+    input = <<-EOT
+{
+  "StateMachineArn": "${var.state_machine_arn}",
+  "Name": "cfe_nom_analysis_assim_extend_vpu${each.value.vpu}_init${each.value.init}_<aws.scheduler.execution-id>",
+  "Input": ${each.value.vpu == "fp" ? jsonencode(templatefile(local.fp_template_path, {
+    init               = each.value.init
+    run_type_l         = each.value.run_type_l
+    run_type_h         = each.value.run_type_h
+    member_suffix      = each.value.member_suffix
+    ami_id             = local.fp_ami_id
+    instance_type      = each.value.instance_type
+    instance_profile   = local.fp_instance_profile
+    volume_size        = each.value.volume_size
+    timeout_s          = 3600
+    environment_suffix = var.environment_suffix
+    s3_bucket          = var.s3_bucket
+    vpu_list           = local.fp_vpu_list
+    })) : jsonencode(templatefile(local.cfe_nom_template_path, {
+    vpu                = each.value.vpu
+    init               = each.value.init
+    run_type_l         = each.value.run_type_l
+    run_type_h         = each.value.run_type_h
+    fcst               = each.value.fcst
+    member             = each.value.member
+    member_suffix      = each.value.member_suffix
+    member_path        = each.value.member_path
+    nprocs             = each.value.nprocs
+    ami_id             = local.cfe_nom_ami_id
+    instance_type      = each.value.instance_type
+    instance_profile   = local.cfe_nom_instance_profile
+    volume_size        = each.value.volume_size
+    timeout_s          = 3600
+    environment_suffix = var.environment_suffix
+    s3_bucket          = var.s3_bucket
+}))}
+}
+EOT
+}
+}

--- a/infra/aws/terraform/services/nrds/datastreams/cfe-nom/templates/execution_datastream_cfe_nom_VPU_template.json.tpl
+++ b/infra/aws/terraform/services/nrds/datastreams/cfe-nom/templates/execution_datastream_cfe_nom_VPU_template.json.tpl
@@ -1,0 +1,53 @@
+{
+  "commands": [
+    "runuser -l ec2-user -c 'export SKIP_VALIDATION=True DS_TAG=1.4.0 NGIAB_TAG=v1.7.0 && /home/ec2-user/datastreamcli/scripts/datastream -s DAILY -n ${nprocs} -F s3://${s3_bucket}/forcings/v2.2_hydrofabric/ngen.DAILY/forcing_${run_type_l}/${init}/ngen.t${init}z.${run_type_l}.forcing.${fcst}.VPU_${vpu}.nc --FORCING_SOURCE NWM_V3_${run_type_h}_${init}${member_suffix} -d /home/ec2-user/outputs -N s3://${s3_bucket}/resources/v2.2_hydrofabric/bmi_configs/cfe_nom_fixed/VPU_${vpu}/config/ngen-bmi-configs.tar.gz -g s3://${s3_bucket}/resources/v2.2_hydrofabric/geopackages/VPU_${vpu}/nextgen_VPU_${vpu}.gpkg -R https://${s3_bucket}.s3.amazonaws.com/realizations/cfe_nom/realization_VPU_${vpu}.json --S3_BUCKET ${s3_bucket} --S3_PREFIX outputs/cfe_nom/v2.2_hydrofabric/ngen.DAILY/${run_type_l}/${init}${member_path}/VPU_${vpu}'"
+  ],
+  "run_options": {
+    "ii_terminate_instance": true,
+    "ii_delete_volume": true,
+    "ii_check_s3": true,
+    "ii_cheapo": true,
+    "timeout_s": ${timeout_s},
+    "n_retries_allowed": 2
+  },
+  "instance_parameters": {
+    "ImageId": "${ami_id}",
+    "InstanceType": "${instance_type}",
+    "IamInstanceProfile": {
+      "Name": "${instance_profile}"
+    },
+    "TagSpecifications": [
+      {
+        "ResourceType": "instance",
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "${environment_suffix}_CFE_NOM_${run_type_l}_VPU${vpu}_init${init}${member_suffix}"
+          },
+          {
+            "Key": "Project",
+            "Value": "datastream_FULLCONUS_v1.2_${run_type_l}_${vpu}"
+          }
+        ]
+      },
+      {
+        "ResourceType": "volume",
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "${environment_suffix}_CFE_NOM_${run_type_l}_VPU${vpu}_init${init}${member_suffix}_vol"
+          }
+        ]
+      }
+    ],
+    "BlockDeviceMappings": [
+      {
+        "DeviceName": "/dev/xvda",
+        "Ebs": {
+          "VolumeSize": ${volume_size},
+          "VolumeType": "gp3"
+        }
+      }
+    ]
+  }
+}

--- a/infra/aws/terraform/services/nrds/datastreams/cfe-nom/templates/execution_datastream_cfe_nom_fp_template.json.tpl
+++ b/infra/aws/terraform/services/nrds/datastreams/cfe-nom/templates/execution_datastream_cfe_nom_fp_template.json.tpl
@@ -1,0 +1,60 @@
+{
+  "commands": [
+    "runuser -l ec2-user -c 'mkdir -p /home/ec2-user/run/datastream-metadata'",
+    "runuser -l ec2-user -c 'mkdir -p /home/ec2-user/run/ngen-run/config'",
+    "runuser -l ec2-user -c 'cp /home/ec2-user/ngen-datastream/configs/ngen/realization_sloth_nom_cfe_pet.json /home/ec2-user/run'",
+    "runuser -l ec2-user -c 'docker run --rm -v /home/ec2-user/run:/mounted_dir -u $(id -u):$(id -g) -w /mounted_dir/datastream-metadata awiciroh/datastream:1.0.2 python3 /ngen-datastream/python_tools/src/python_tools/configure_datastream.py --docker_mount /mounted_dir --start_date DAILY --data_dir /home/ec2-user/run --forcing_source NWM_V3_${run_type_h}_${init}${member_suffix} --forcing_split_vpu ${vpu_list} --hydrofabric_version v2.2 --realization /mounted_dir/realization_sloth_nom_cfe_pet.json --realization_provided /home/ec2-user/run/realization_sloth_nom_cfe_pet.json --s3_bucket ${s3_bucket} --s3_prefix forcings/v2.2_hydrofabric/ngen.DAILY/forcing_${run_type_l}/${init}'",
+    "runuser -l ec2-user -c 'docker run --rm -v /home/ec2-user/run:/mounted_dir -u $(id -u):$(id -g) -w /mounted_dir/datastream-metadata awiciroh/forcingprocessor:1.0.3 python3 /ngen-datastream/forcingprocessor/src/forcingprocessor/nwm_filenames_generator.py /mounted_dir/datastream-metadata/conf_nwmurl.json'",
+    "runuser -l ec2-user -c 'cp /home/ec2-user/hydrofabric/v2.2/nextgen_*_weights.json /home/ec2-user/run'",
+    "runuser -l ec2-user -c 'docker run --rm -e AWS_ACCESS_KEY_ID=$(echo $AWS_ACCESS_KEY_ID) -e AWS_SECRET_ACCESS_KEY=$(echo $AWS_SECRET_ACCESS_KEY) -v /home/ec2-user/run:/mounted_dir -u $(id -u):$(id -g) -w /mounted_dir/datastream-metadata awiciroh/forcingprocessor:1.0.3 python3 /ngen-datastream/forcingprocessor/src/forcingprocessor/processor.py /mounted_dir/datastream-metadata/conf_fp.json'",
+    "runuser -l ec2-user -c 'aws s3 cp /home/ec2-user/run/datastream-metadata/conf_nwmurl.json $(cat /home/ec2-user/run/datastream-metadata/conf_fp.json | jq -r '.storage.output_path')/metadata/forcings_metadata/conf_nwmurl.json --no-progress'"
+  ],
+  "run_options": {
+    "ii_terminate_instance": true,
+    "ii_delete_volume": true,
+    "ii_check_s3": true,
+    "ii_cheapo": true,
+    "timeout_s": ${timeout_s},
+    "n_retries_allowed": 2
+  },
+  "instance_parameters": {
+    "ImageId": "${ami_id}",
+    "InstanceType": "${instance_type}",
+    "IamInstanceProfile": {
+      "Name": "${instance_profile}"
+    },
+    "TagSpecifications": [
+      {
+        "ResourceType": "instance",
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "${environment_suffix}_CFE_NOM_${run_type_l}_fp_init${init}${member_suffix}"
+          },
+          {
+            "Key": "Project",
+            "Value": "datastream_FULLCONUS_v1.2_${run_type_l}_fp"
+          }
+        ]
+      },
+      {
+        "ResourceType": "volume",
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "${environment_suffix}_CFE_NOM_${run_type_l}_fp_init${init}${member_suffix}_vol"
+          }
+        ]
+      }
+    ],
+    "BlockDeviceMappings": [
+      {
+        "DeviceName": "/dev/xvda",
+        "Ebs": {
+          "VolumeSize": ${volume_size},
+          "VolumeType": "gp3"
+        }
+      }
+    ]
+  }
+}

--- a/infra/aws/terraform/services/nrds/envs/prod.tfvars
+++ b/infra/aws/terraform/services/nrds/envs/prod.tfvars
@@ -21,6 +21,8 @@ scheduler_policy_name = "nrds_prod_scheduler_policy"
 scheduler_role_name   = "nrds_prod_scheduler_role"
 
 # Per-datastream AMIs
+cfe_nom_ami_id      = "ami-038132f534157b5c3"
+fp_ami_id           = "ami-062245e1c9604128d"
 routing_only_ami_id = "ami-0f8e27ecfe91ffd4f"
 
 # Schedule settings

--- a/infra/aws/terraform/services/nrds/main.tf
+++ b/infra/aws/terraform/services/nrds/main.tf
@@ -47,6 +47,24 @@ module "nrds_orchestration" {
 # To add a new datastream: add a module block here and a directory under datastreams/
 # =============================================================================
 
+module "cfe_nom_schedules" {
+  source = "./datastreams/cfe-nom"
+
+  region               = var.region
+  state_machine_arn    = module.nrds_orchestration.datastream_arn
+  scheduler_role_arn   = aws_iam_role.scheduler_role.arn
+  ec2_instance_profile = module.nrds_orchestration.ec2_instance_profile_name
+
+  cfe_nom_ami_id = var.cfe_nom_ami_id
+  fp_ami_id      = var.fp_ami_id
+
+  schedule_timezone   = var.schedule_timezone
+  schedule_group_name = var.schedule_group_name
+  environment_suffix  = var.environment_suffix
+
+  s3_bucket = var.s3_bucket
+}
+
 module "routing_only_schedules" {
   source = "./datastreams/routing-only"
 

--- a/infra/aws/terraform/services/nrds/outputs.tf
+++ b/infra/aws/terraform/services/nrds/outputs.tf
@@ -18,6 +18,18 @@ output "ec2_instance_profile_name" {
   value = module.nrds_orchestration.ec2_instance_profile_name
 }
 
+output "cfe_nom_short_range_schedule_count" {
+  value = module.cfe_nom_schedules.short_range_schedule_count
+}
+
+output "cfe_nom_medium_range_schedule_count" {
+  value = module.cfe_nom_schedules.medium_range_schedule_count
+}
+
+output "cfe_nom_analysis_assim_schedule_count" {
+  value = module.cfe_nom_schedules.analysis_assim_schedule_count
+}
+
 output "routing_only_short_range_schedule_count" {
   value = module.routing_only_schedules.short_range_schedule_count
 }

--- a/infra/aws/terraform/services/nrds/variables.tf
+++ b/infra/aws/terraform/services/nrds/variables.tf
@@ -34,6 +34,18 @@ variable "scheduler_role_name" {
 }
 
 # Per-datastream AMIs
+variable "cfe_nom_ami_id" {
+  type        = string
+  description = "AMI ID for CFE_NOM model EC2 instances"
+  default     = "ami-038132f534157b5c3"
+}
+
+variable "fp_ami_id" {
+  type        = string
+  description = "AMI ID for forcing processor EC2 instances"
+  default     = "ami-062245e1c9604128d"
+}
+
 variable "routing_only_ami_id" {
   type        = string
   description = "AMI ID for Routing-Only model EC2 instances"


### PR DESCRIPTION
## Summary

Adds CFE NOM as a second datastream module on top of the shared infrastructure from #315. **Zero workflow changes needed** — this PR proves the pattern works.

- Adds `datastreams/cfe-nom/` with short range (456 schedules), medium range (160 schedules), and analysis_assim_extend (20 schedules) = **636 total schedules**
- `nprocs` computed from instance type (`vCPUs - 1`), matching prod behavior
- `timeout_s` varies per forecast type: 3600s (short_range, AnA), 7200s (medium_range)
- VPU 17 excluded (no S3 resources exist in prod)
- Adds `cfe_nom_ami_id` and `fp_ami_id` variables

## Changes (on top of #315)

- `datastreams/cfe-nom/` — schedules, config, templates (new)
- `main.tf` — add `cfe_nom_schedules` module block
- `variables.tf` — add `cfe_nom_ami_id`, `fp_ami_id`
- `outputs.tf` — add cfe-nom schedule counts
- `prod.tfvars` — add AMI values
- `README.md` — add cfe-nom to directory structure

## Test plan

- [ ] `terraform validate` passes
- [ ] `terraform plan` shows 636 cfe-nom schedules + 24 routing-only = 660 total
- [ ] No workflow file changes in this diff