### PR TITLE
Add key-pair resource to Lambda IAM policy

### DIFF
--- a/infra/aws/terraform/modules/orchestration/iam_lambda.tf
+++ b/infra/aws/terraform/modules/orchestration/iam_lambda.tf
@@ -35,6 +35,7 @@ resource "aws_iam_policy" "datastreamlambda_policy" {
           "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:network-interface/*",
           "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:security-group/*",
           "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:subnet/*",
+          "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:key-pair/*",
           "arn:aws:ec2:${data.aws_region.current.name}::image/*"
         ]
       },


### PR DESCRIPTION
- Adds `key-pair/*` ARN to the `ec2:RunInstances` resource list in the Lambda IAM policy
- The IAM scoping in PR #328 missed this resource, causing `ec2:RunInstances` to fail with `is not authorized to perform: ec2:RunInstances on resource: key-pair/actions_key_arm`
