### PR TITLE
fix: remove local_file causing daily drift false positive (#324)

### DIFF
--- a/infra/aws/terraform/modules/orchestration/main.tf
+++ b/infra/aws/terraform/modules/orchestration/main.tf
@@ -13,10 +13,6 @@ terraform {
       source  = "hashicorp/archive"
       version = "~> 2.0"
     }
-    local = {
-      source  = "hashicorp/local"
-      version = "~> 2.0"
-    }
   }
 }
 

--- a/infra/aws/terraform/modules/orchestration/outputs.tf
+++ b/infra/aws/terraform/modules/orchestration/outputs.tf
@@ -39,8 +39,3 @@ output "lambda_function_names" {
   ]
   description = "Names of all Lambda functions in the orchestration workflow"
 }
-
-resource "local_file" "write_arn" {
-  content  = aws_sfn_state_machine.datastream_state_machine.arn
-  filename = "${path.module}/sm_ARN.txt"
-}


### PR DESCRIPTION
## Summary

- Removes `local_file.write_arn` from the orchestration module — this resource writes `sm_ARN.txt` to disk, which always shows as "1 to add" in CI since runners are ephemeral
- Removes the now-unused `hashicorp/local` provider requirement
- The state machine ARN remains available via the existing `datastream_arn` output

Closes #324