### PR TITLE
add troute restart flags to routing-only template

### DIFF
--- a/infra/aws/terraform/services/nrds/datastreams/routing-only/templates/execution_datastream_routing_only_VPU_template.json.tpl
+++ b/infra/aws/terraform/services/nrds/datastreams/routing-only/templates/execution_datastream_routing_only_VPU_template.json.tpl
@@ -1,6 +1,6 @@
 {
   "commands": [
-    "su - ec2-user -c 'rm -rf /home/ec2-user/outputs && export SKIP_VALIDATION=True DS_TAG=1.7.0 NGIAB_TAG=v1.7.0 && /home/ec2-user/datastreamcli/scripts/datastream -s DAILY -n ${nprocs} --FORCING_SOURCE NWM_V3_CHRTOUT_${run_type_h}_${init} -d /home/ec2-user/outputs -g s3://${s3_bucket}/resources/v2.2_hydrofabric/geopackages/VPU_${vpu}/nextgen_VPU_${vpu}.gpkg -R https://${s3_bucket}.s3.amazonaws.com/realizations/routing_only/realization_sloth_troute.json -t run/ngen-run/restart/channel_restart.nc -w s3://${s3_bucket}/resources/v2.2_hydrofabric/troute_restart/crosswalk.nc --S3_BUCKET ${s3_bucket} --S3_PREFIX outputs/routing_only/v2.2_hydrofabric/ngen.DAILY/${run_type_l}/${init}/VPU_${vpu}'"
+    "su - ec2-user -c 'rm -rf /home/ec2-user/outputs && export SKIP_VALIDATION=True DS_TAG=1.7.0 NGIAB_TAG=v1.7.0 && /home/ec2-user/datastreamcli/scripts/datastream -s DAILY -n ${nprocs} --FORCING_SOURCE NWM_V3_CHRTOUT_${run_type_h}_${init} -d /home/ec2-user/outputs -g s3://${s3_bucket}/resources/v2.2_hydrofabric/geopackages/VPU_${vpu}/nextgen_VPU_${vpu}.gpkg -R https://${s3_bucket}.s3.amazonaws.com/realizations/routing_only/realization_sloth_troute.json -t s3://${s3_bucket}/restarts/v2.2_hydrofabric/ngen.DAILY/${init}/channel_restart_DAILY_${init}0000.nc -w s3://${s3_bucket}/resources/v2.2_hydrofabric/troute_restart/crosswalk.nc --S3_BUCKET ${s3_bucket} --S3_PREFIX outputs/routing_only/v2.2_hydrofabric/ngen.DAILY/${run_type_l}/${init}/VPU_${vpu}'"
   ],
   "run_options": {
     "ii_terminate_instance": true,

--- a/infra/aws/terraform/services/nrds/datastreams/routing-only/templates/execution_datastream_routing_only_VPU_template.json.tpl
+++ b/infra/aws/terraform/services/nrds/datastreams/routing-only/templates/execution_datastream_routing_only_VPU_template.json.tpl
@@ -1,6 +1,6 @@
 {
   "commands": [
-    "su - ec2-user -c 'rm -rf /home/ec2-user/outputs && export SKIP_VALIDATION=True DS_TAG=1.4.0 NGIAB_TAG=v1.7.0 && /home/ec2-user/datastreamcli/scripts/datastream -s DAILY -n ${nprocs} --FORCING_SOURCE NWM_V3_CHRTOUT_${run_type_h}_${init} -d /home/ec2-user/outputs -g s3://${s3_bucket}/resources/v2.2_hydrofabric/geopackages/VPU_${vpu}/nextgen_VPU_${vpu}.gpkg -R https://${s3_bucket}.s3.amazonaws.com/realizations/routing_only/realization_sloth_troute.json --S3_BUCKET ${s3_bucket} --S3_PREFIX outputs/routing_only/v2.2_hydrofabric/ngen.DAILY/${run_type_l}/${init}/VPU_${vpu}'"
+    "su - ec2-user -c 'rm -rf /home/ec2-user/outputs && export SKIP_VALIDATION=True DS_TAG=1.7.0 NGIAB_TAG=v1.7.0 && /home/ec2-user/datastreamcli/scripts/datastream -s DAILY -n ${nprocs} --FORCING_SOURCE NWM_V3_CHRTOUT_${run_type_h}_${init} -d /home/ec2-user/outputs -g s3://${s3_bucket}/resources/v2.2_hydrofabric/geopackages/VPU_${vpu}/nextgen_VPU_${vpu}.gpkg -R https://${s3_bucket}.s3.amazonaws.com/realizations/routing_only/realization_sloth_troute.json -t run/ngen-run/restart/channel_restart.nc -w s3://${s3_bucket}/resources/v2.2_hydrofabric/troute_restart/crosswalk.nc --S3_BUCKET ${s3_bucket} --S3_PREFIX outputs/routing_only/v2.2_hydrofabric/ngen.DAILY/${run_type_l}/${init}/VPU_${vpu}'"
   ],
   "run_options": {
     "ii_terminate_instance": true,


### PR DESCRIPTION
Update DS_TAG to 1.7.0, add -t (restart) and -w (crosswalk) flags for troute restarts.