### PR TITLE
update routing_only AMI with DAILY resolution fix

### DIFF
--- a/infra/aws/terraform/services/nrds/envs/prod.tfvars
+++ b/infra/aws/terraform/services/nrds/envs/prod.tfvars
@@ -23,7 +23,7 @@ scheduler_role_name   = "nrds_prod_scheduler_role"
 # Per-datastream AMIs
 cfe_nom_ami_id      = "ami-038132f534157b5c3"
 fp_ami_id           = "ami-062245e1c9604128d"
-routing_only_ami_id = "ami-0e28d2f2d8491620b"
+routing_only_ami_id = "ami-02cb92f166b83470e"
 lstm_0_ami_id       = "ami-038132f534157b5c3"
 restart_ami_id      = "ami-0e28d2f2d8491620b"
 


### PR DESCRIPTION
New AMI ami-02cb92f166b83470e has the DAILY→run_date replacement applied to the cli args flow at scripts/datastream line 442. Fixes the failing routing-only executions that couldn't find channel_restart_DAILY_*.nc files. Pending datastreamcli#95 being merged, at which point this patch can be removed from the AMI build.