### PR TITLE
streamcommander: handle ANALYSIS_ASSIM_RESTART_CHRT forcing source

### DIFF
--- a/infra/aws/terraform/modules/orchestration/lambdas/streamcommander/lambda_function.py
+++ b/infra/aws/terraform/modules/orchestration/lambdas/streamcommander/lambda_function.py
@@ -86,7 +86,9 @@ def lambda_handler(event, context):
             if "SHORT_RANGE" in forcing_source:
                 fcst_cycle = int(forcing_source[-2:])
             elif "MEDIUM_RANGE" in forcing_source:
-                fcst_cycle = int(forcing_source[-4:-2])          
+                fcst_cycle = int(forcing_source[-4:-2])
+            elif "ANALYSIS_ASSIM_RESTART_CHRT" in forcing_source:
+                fcst_cycle = int(forcing_source[-2:])
             if today.hour < fcst_cycle:
                 today = (today - timedelta(days=1))
             today = today.strftime('%Y%m%d')        


### PR DESCRIPTION
Restart datastream's DAILY resolution was falling to the default fcst_cycle=16, causing the S3 directory to resolve to yesterday's date while the filename resolved to today's — leaving routing-only unable to find the file. Adds an elif that mirrors the SHORT_RANGE/MEDIUM_RANGE pattern so init hour is used as the cutoff.