### PR TITLE
downsize routing-only to m8g.large

### DIFF
--- a/infra/aws/terraform/services/nrds/datastreams/routing-only/config/execution_forecast_inputs_routing_only.json
+++ b/infra/aws/terraform/services/nrds/datastreams/routing-only/config/execution_forecast_inputs_routing_only.json
@@ -7,7 +7,7 @@
       "18", "19", "20", "21", "22", "23"
     ],
     "instance_types": {
-      "03W": "m8g.xlarge"
+      "03W": "m8g.large"
     },
     "volume_size": 64
   }


### PR DESCRIPTION
## Summary
- Drop `routing_only` short_range VPU 03W instance from `m8g.xlarge` (4 vCPU, 16 GB) to `m8g.large` (2 vCPU, 8 GB).

First post-merge run after PR #358 (`prod_routing_only_short_range_VPU03W_init12`, 2026-04-27 17:00 UTC):

| Metric | Value (m8g.xlarge) |
|---|---|
| Peak CPU | **44.55%** |
| Avg CPU | 17.7% |
| NetworkIn | 599 MB / min (S3 pulls) |
| NetworkOut | 1.8 MB / min |

NGEN runtime ~37s, FP ~54s, total datastream ~2.5 min. ~1.8 of 4 vCPU peak — clear over-provisioning.

On `m8g.large` the same workload projects to ~89% peak CPU / ~35% avg — comfortable headroom. Restart NC is 26 MB and NPROCS=4 troute workers should fit well within 8 GB.
