### PR TITLE
streamcommander: bump SSM send_command timeout to 300s

### DIFF
--- a/infra/aws/terraform/modules/orchestration/lambdas/streamcommander/lambda_function.py
+++ b/infra/aws/terraform/modules/orchestration/lambdas/streamcommander/lambda_function.py
@@ -193,7 +193,7 @@ def lambda_handler(event, context):
     client_ssm = boto3.client('ssm')
     print(f'Client established, sending command')
     ii_send_command = True
-    max_wait = 120
+    max_wait = 300
     start_time = time.time()
     while ii_send_command:
         if time.time() - start_time > max_wait:


### PR DESCRIPTION
SSM agent registration on cold-start EC2 occasionally exceeds 120s, causing
streamcommander to raise `TimeoutError` before `send_command` succeeds. Bumps
the wait from 120s → 300s to cover the long tail.

### Observed failure (recent example)

Execution: `lstm_0_short_range_vpu10L_init06_7169f87c-3043-43cc-85a5-34da9be7b6ff`

```
TaskFailed (Commander):
  TimeoutError: Timed out waiting to send command to instance
  File "/var/task/lambda_function.py", line 200

TaskFailed (EC2Stopper, cascade):
  KeyError: 'volume_id'
  File "/var/task/lambda_function.py", line 48: 'Values': [event['volume_id']]
```

Timeline: EC2 launched at 16:20:07 UTC, Commander entered same second, timed
out 127s later (16:22:14 UTC). Total execution wall time: 2m15s.

### Frequency

Recurring intermittent — ~1–2 failures/day across LSTM and CFE-NOM datastreams
over the past week:

```
2026-05-04  lstm_0_short_range_vpu10L_init06     ← this one
2026-05-03  lstm_0_short_range_vpu03W_init10
2026-05-03  lstm_0_short_range_vpu03W_init21
2026-05-02  cfe_nom_short_range_vpu05_init11
2026-05-02  cfe_nom_short_range_vpu05_init21
2026-05-01  lstm_0_short_range_vpu15_init14
2026-05-01  lstm_0_short_range_vpu03S_init09
… (~1–2/day)
```

Scattered across VPUs and init cycles, on the same shared AMI/IAM/template
that other peer executions succeed on at the same time. Classic SSM agent
registration latency variance — usually 30–60s, but tail can hit 90–180s
under load.

### Followups (separate PRs)

- Stopper should `event.get('volume_id')` to avoid the cascade KeyError
  when streamcommander dies before setting it.
- SM `Commander` state could `Retry` on `TimeoutError` for an in-place retry
  without re-launching the EC2.