### PR TITLE
streamcommander: bump SSM send_command timeout to 300s

### DIFF
--- a/infra/aws/terraform/modules/orchestration/lambdas/streamcommander/lambda_function.py
+++ b/infra/aws/terraform/modules/orchestration/lambdas/streamcommander/lambda_function.py
@@ -193,7 +193,7 @@ def lambda_handler(event, context):
     client_ssm = boto3.client('ssm')
     print(f'Client established, sending command')
     ii_send_command = True
-    max_wait = 120
+    max_wait = 300
     start_time = time.time()
     while ii_send_command:
         if time.time() - start_time > max_wait:


### PR DESCRIPTION
SSM agent registration on cold-start EC2 occasionally exceeds 120s, causing streamcommander to hit `TimeoutError` before `send_command` succeeds. Observed ~1-2 false failures/day across LSTM and CFE-NOM. Bumps wait to 300s.

Recent example: `lstm_0_short_range_vpu10L_init06_7169f87c-3043-43cc-85a5-34da9be7b6ff`