### PR TITLE
Add qkrig (USGS streamflow kriging) as an NRDS datastream

### DIFF
--- a/infra/aws/terraform/modules/orchestration/lambdas/streamcommander/lambda_function.py
+++ b/infra/aws/terraform/modules/orchestration/lambdas/streamcommander/lambda_function.py
@@ -59,6 +59,7 @@ def lambda_handler(event, context):
         event.pop("datastream_command_options")  
 
     forcing_file = None
+    forcing_source = None
     for jcmd in event["commands"]:
         bucket_pattern = r"(?i)--s3_bucket[=\s']+([^\s']+)"
         match = re.search(bucket_pattern, jcmd)
@@ -83,25 +84,30 @@ def lambda_handler(event, context):
             # Create s3 path with DAILY replaced
             prefix_daily = prefix
             fcst_cycle = 16 # for analysis assim extend
-            if "SHORT_RANGE" in forcing_source:
-                fcst_cycle = int(forcing_source[-2:])
-            elif "MEDIUM_RANGE" in forcing_source:
-                fcst_cycle = int(forcing_source[-4:-2])
-            elif "ANALYSIS_ASSIM_RESTART_CHRT" in forcing_source:
-                fcst_cycle = int(forcing_source[-2:])
+            if forcing_source:
+                if "SHORT_RANGE" in forcing_source:
+                    fcst_cycle = int(forcing_source[-2:])
+                elif "MEDIUM_RANGE" in forcing_source:
+                    fcst_cycle = int(forcing_source[-4:-2])
+                elif "ANALYSIS_ASSIM_RESTART_CHRT" in forcing_source:
+                    fcst_cycle = int(forcing_source[-2:])
+            else:
+                fcst_cycle = 24
             if today.hour < fcst_cycle:
                 today = (today - timedelta(days=1))
-            today = today.strftime('%Y%m%d')        
-            prefix = re.sub(r"\DAILY",today,prefix)   
+            today = today.strftime('%Y%m%d')
+            prefix = re.sub(r"\DAILY",today,prefix)
             escaped_path = re.escape(prefix_daily)
             prefix_daily_pattern = escaped_path.replace('DAILY', r'(?P<date>DAILY)')
 
             for j,jcmd in enumerate(event["commands"]):
                 match = re.search(prefix_daily_pattern, jcmd)
                 replacement = prefix_daily.replace('DAILY', today)
-                if match: 
+                if match:
                     new_str = re.sub(prefix_daily_pattern, replacement, jcmd)
                     event["commands"][j] = re.sub(prefix_daily_pattern, replacement, jcmd)
+                if forcing_source is None:
+                    event["commands"][j] = re.sub(r'(?<![A-Za-z0-9])DAILY(?![A-Za-z0-9])', today, event["commands"][j])
 
         if forcing_file is not None:
             # Shifting forcing file times based on ensemble member
@@ -112,7 +118,7 @@ def lambda_handler(event, context):
 
             shifted_forcing = forcing_file  # default, if no shift occurs
 
-            if "MEDIUM_RANGE" in forcing_source:
+            if forcing_source and "MEDIUM_RANGE" in forcing_source:
                 ensemble_member = int(forcing_source[-1]) 
                 nhrs_shift = 6 * (ensemble_member - 1) 
                 m = re.search(r'/(\d{2})/.*?t(\d{2})z', forcing_file)

--- a/infra/aws/terraform/services/nrds/datastreams/qkrig/config/execution_forecast_inputs_qkrig.json
+++ b/infra/aws/terraform/services/nrds/datastreams/qkrig/config/execution_forecast_inputs_qkrig.json
@@ -1,0 +1,6 @@
+{
+  "init_cycles": ["00"],
+  "instance_type": "m8g.4xlarge",
+  "volume_size": 100,
+  "timeout_s": 9000
+}

--- a/infra/aws/terraform/services/nrds/datastreams/qkrig/main.tf
+++ b/infra/aws/terraform/services/nrds/datastreams/qkrig/main.tf
@@ -1,0 +1,49 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+variable "region" {}
+
+variable "scheduler_role_arn" {
+  type        = string
+  description = "ARN of the shared scheduler IAM role"
+}
+
+variable "state_machine_arn" {
+  type = string
+}
+
+variable "ec2_instance_profile" {
+  type        = string
+  description = "IAM instance profile name for EC2"
+}
+
+variable "qkrig_ami_id" {
+  type        = string
+  description = "AMI ID for qkrig EC2 instances (must have docker + awiciroh/qkrig pre-pulled)"
+}
+
+variable "schedule_timezone" {
+  type    = string
+  default = "America/New_York"
+}
+
+variable "schedule_group_name" {
+  type    = string
+  default = "default"
+}
+
+variable "environment_suffix" {
+  type = string
+}
+
+variable "s3_bucket" {
+  type    = string
+  default = "ciroh-community-ngen-datastream"
+}

--- a/infra/aws/terraform/services/nrds/datastreams/qkrig/outputs.tf
+++ b/infra/aws/terraform/services/nrds/datastreams/qkrig/outputs.tf
@@ -1,0 +1,3 @@
+output "qkrig_daily_schedule_names" {
+  value = [for s in aws_scheduler_schedule.qkrig_daily_schedule : s.name]
+}

--- a/infra/aws/terraform/services/nrds/datastreams/qkrig/schedules.tf
+++ b/infra/aws/terraform/services/nrds/datastreams/qkrig/schedules.tf
@@ -1,0 +1,49 @@
+locals {
+  qkrig_config = jsondecode(file("${path.module}/config/execution_forecast_inputs_qkrig.json"))
+
+  qkrig_template_path = "${path.module}/templates/execution_qkrig_daily_template.json.tpl"
+
+  qkrig_daily_schedules = {
+    for init in local.qkrig_config.init_cycles : init => {
+      init          = init
+      instance_type = local.qkrig_config.instance_type
+      volume_size   = local.qkrig_config.volume_size
+      timeout_s     = local.qkrig_config.timeout_s
+    }
+  }
+}
+
+resource "aws_scheduler_schedule" "qkrig_daily_schedule" {
+  for_each = local.qkrig_daily_schedules
+
+  name       = "qkrig_init${each.value.init}_schedule_${var.environment_suffix}"
+  group_name = var.schedule_group_name
+
+  flexible_time_window {
+    mode = "OFF"
+  }
+
+  schedule_expression          = "cron(30 ${tonumber(each.value.init) % 24} * * ? *)"
+  schedule_expression_timezone = var.schedule_timezone
+
+  target {
+    arn      = "arn:aws:scheduler:::aws-sdk:sfn:startExecution"
+    role_arn = var.scheduler_role_arn
+    input = <<-EOT
+{
+  "StateMachineArn": "${var.state_machine_arn}",
+  "Name": "qkrig_init${each.value.init}_<aws.scheduler.execution-id>",
+  "Input": ${jsonencode(templatefile(local.qkrig_template_path, {
+    init               = each.value.init
+    ami_id             = var.qkrig_ami_id
+    instance_type      = each.value.instance_type
+    instance_profile   = var.ec2_instance_profile
+    volume_size        = each.value.volume_size
+    timeout_s          = each.value.timeout_s
+    environment_suffix = var.environment_suffix
+    s3_bucket          = var.s3_bucket
+}))}
+}
+EOT
+}
+}

--- a/infra/aws/terraform/services/nrds/datastreams/qkrig/templates/execution_qkrig_daily_template.json.tpl
+++ b/infra/aws/terraform/services/nrds/datastreams/qkrig/templates/execution_qkrig_daily_template.json.tpl
@@ -1,0 +1,54 @@
+{
+  "commands": [
+    "echo --s3_bucket ${s3_bucket} --s3_prefix outputs/qkrig/qkrig.DAILY  # parser hint; streamcommander substitutes DAILY token to yesterday's UTC date (YYYYMMDD)",
+    "runuser -l ec2-user -c 'mkdir -p /home/ec2-user/run/datastream-metadata /home/ec2-user/kv /home/ec2-user/exports /home/ec2-user/hydrofabric'",
+    "runuser -l ec2-user -c 'rm -rf /home/ec2-user/hydrofabric/conus_nextgen.gpkg; { aws s3 cp s3://${s3_bucket}/resources/v2.2_hydrofabric/conus_nextgen.gpkg /home/ec2-user/hydrofabric/conus_nextgen.gpkg --no-progress; echo \"AWS_S3_CP_EXIT=$?\"; ls -la /home/ec2-user/hydrofabric/; file /home/ec2-user/hydrofabric/conus_nextgen.gpkg 2>&1 || true; } 2>&1 | tee /home/ec2-user/run/setup.log; aws s3 cp /home/ec2-user/run/setup.log s3://${s3_bucket}/outputs/qkrig/qkrig.DAILY/logs/setup.log --no-progress || true; test -s /home/ec2-user/hydrofabric/conus_nextgen.gpkg || { echo \"FATAL: gpkg missing/empty\"; exit 1; }'",
+    "runuser -l ec2-user -c 'DATE=DAILY && DATE=$${DATE:0:4}-$${DATE:4:2}-$${DATE:6:2} && docker run --rm -e DATE=$${DATE} -e MAX_PROCS=4 -v /home/ec2-user/kv:/qkrig/usgs_hourly_retrieval_logs -v /home/ec2-user/exports:/qkrig/exports -v /home/ec2-user/hydrofabric/conus_nextgen.gpkg:/qkrig/hydrofabric/conus_nextgen.gpkg:ro -u $(id -u):$(id -g) awiciroh/qkrig:2.2.0 2>&1 | tee /home/ec2-user/run/docker.log'",
+    "runuser -l ec2-user -c 'DATE=DAILY && DATE=$${DATE:0:4}-$${DATE:4:2}-$${DATE:6:2} && aws s3 cp /home/ec2-user/kv s3://${s3_bucket}/outputs/qkrig/cache/kv/ --recursive --exclude \"*\" --include \"$${DATE}_*.kv.txt\" --no-progress'",
+    "runuser -l ec2-user -c 'DATE=DAILY && DATE=$${DATE:0:4}-$${DATE:4:2}-$${DATE:6:2} && rm -rf /tmp/staging && mkdir -p /tmp/staging && for h in 00 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23; do if [ -e /home/ec2-user/exports/interp_$${DATE}_$${h}.nc ]; then mkdir -p /tmp/staging/$${h} && cp /home/ec2-user/exports/interp_$${DATE}_$${h}.nc /home/ec2-user/exports/variogram_$${DATE}_$${h}.csv /tmp/staging/$${h}/; fi; done && aws s3 sync /tmp/staging s3://${s3_bucket}/outputs/qkrig/qkrig.DAILY/ --no-progress'",
+    "runuser -l ec2-user -c 'PARQUET=/home/ec2-user/exports/catchment_csv/qkrig_output_DAILY.parquet && [ -s \"$PARQUET\" ] && aws s3 cp \"$PARQUET\" s3://${s3_bucket}/outputs/qkrig/qkrig.DAILY/qkrig_output_DAILY.parquet --no-progress || true'",
+    "runuser -l ec2-user -c '[ -s /home/ec2-user/run/docker.log ] && aws s3 cp /home/ec2-user/run/docker.log s3://${s3_bucket}/outputs/qkrig/qkrig.DAILY/logs/docker.log --no-progress || true'",
+    "runuser -l ec2-user -c 'if [ -d /home/ec2-user/exports/plots ]; then aws s3 sync /home/ec2-user/exports/plots s3://${s3_bucket}/outputs/qkrig/qkrig.DAILY/plots/ --no-progress; fi'",
+    "runuser -l ec2-user -c 'echo \"DATASTREAM_END: $(date -u +%Y%m%d%H%M%S)\" > /home/ec2-user/run/datastream-metadata/profile.txt'",
+    "runuser -l ec2-user -c 'aws s3 cp /home/ec2-user/run/datastream-metadata/profile.txt s3://${s3_bucket}/outputs/qkrig/qkrig.DAILY/datastream-metadata/profile.txt --no-progress'"
+  ],
+  "run_options": {
+    "ii_terminate_instance": true,
+    "ii_delete_volume": true,
+    "ii_check_s3": false,
+    "ii_cheapo": false,
+    "timeout_s": ${timeout_s},
+    "n_retries_allowed": 0
+  },
+  "instance_parameters": {
+    "ImageId": "${ami_id}",
+    "InstanceType": "${instance_type}",
+    "IamInstanceProfile": {
+      "Name": "${instance_profile}"
+    },
+    "TagSpecifications": [
+      {
+        "ResourceType": "instance",
+        "Tags": [
+          {"Key": "Name", "Value": "${environment_suffix}_qkrig_daily"},
+          {"Key": "Project", "Value": "qkrig_daily_FULLCONUS"}
+        ]
+      },
+      {
+        "ResourceType": "volume",
+        "Tags": [
+          {"Key": "Name", "Value": "${environment_suffix}_qkrig_daily_vol"}
+        ]
+      }
+    ],
+    "BlockDeviceMappings": [
+      {
+        "DeviceName": "/dev/xvda",
+        "Ebs": {
+          "VolumeSize": ${volume_size},
+          "VolumeType": "gp3"
+        }
+      }
+    ]
+  }
+}

--- a/infra/aws/terraform/services/nrds/envs/prod.tfvars
+++ b/infra/aws/terraform/services/nrds/envs/prod.tfvars
@@ -33,4 +33,5 @@ schedule_group_name = "default"
 environment_suffix  = "prod"
 
 # S3
-s3_bucket = "ciroh-community-ngen-datastream"
+s3_bucket    = "ciroh-community-ngen-datastream"
+qkrig_ami_id = "ami-0dd297f1f6c52facb"

--- a/infra/aws/terraform/services/nrds/main.tf
+++ b/infra/aws/terraform/services/nrds/main.tf
@@ -132,3 +132,20 @@ module "lstm_0_schedules" {
 
   s3_bucket = var.s3_bucket
 }
+
+module "qkrig_schedules" {
+  source = "./datastreams/qkrig"
+
+  region               = var.region
+  state_machine_arn    = module.nrds_orchestration.datastream_arn
+  scheduler_role_arn   = aws_iam_role.scheduler_role.arn
+  ec2_instance_profile = module.nrds_orchestration.ec2_instance_profile_name
+
+  qkrig_ami_id = var.qkrig_ami_id
+
+  schedule_timezone   = var.schedule_timezone
+  schedule_group_name = var.schedule_group_name
+  environment_suffix  = var.environment_suffix
+
+  s3_bucket = var.s3_bucket
+}

--- a/infra/aws/terraform/services/nrds/outputs.tf
+++ b/infra/aws/terraform/services/nrds/outputs.tf
@@ -57,3 +57,6 @@ output "lstm_0_medium_range_schedule_count" {
 output "lstm_0_analysis_assim_schedule_count" {
   value = module.lstm_0_schedules.analysis_assim_schedule_count
 }
+output "qkrig_daily_schedule_names" {
+  value = module.qkrig_schedules.qkrig_daily_schedule_names
+}

--- a/infra/aws/terraform/services/nrds/variables.tf
+++ b/infra/aws/terraform/services/nrds/variables.tf
@@ -64,6 +64,12 @@ variable "restart_ami_id" {
   default     = "ami-038132f534157b5c3"
 }
 
+variable "qkrig_ami_id" {
+  type        = string
+  description = "AMI ID for qkrig (USGS streamflow kriging) EC2 instances"
+  default     = "ami-0dd297f1f6c52facb"
+}
+
 # Schedule settings
 variable "schedule_timezone" {
   type        = string


### PR DESCRIPTION
Adds qkrig (USGS streamflow kriging) as a daily NRDS datastream. Closes #352.

Runs [DualEarth/qkrig](https://github.com/DualEarth/qkrig) `awiciroh/qkrig:2.2.0` end-to-end on an `m8g.4xlarge` (~38 min/day, 00:30 ET schedule). Publishes 24 hourly NetCDFs + variograms, a `qkrig_output_{YYYYMMDD}.parquet` (~13 MB, 831k catchments × 24 hours), plots + daily GIF, and run logs to `s3://.../outputs/qkrig/qkrig.{YYYYMMDD}/`.

Validated end-to-end on the `test_qkrig` workspace and signed off by Qkrig Team. Steady-state cost ~$192/yr.