### PR TITLE
fix: create_ami.sh path in AMI build workflow

### DIFF
--- a/.github/workflows/build_test_create_ami.yml
+++ b/.github/workflows/build_test_create_ami.yml
@@ -90,8 +90,8 @@ jobs:
           export DS_TAG="$DS_TAG"
           export FP_TAG="$FP_TAG"
           export NGIAB_TAG="$NGIAB_TAG"
-          chmod +x scripts/create_ami.sh
-          ./scripts/create_ami.sh
+          chmod +x shell/create_ami.sh
+          ./shell/create_ami.sh
           
   get-ami-info:
     needs: build-test-push-ami


### PR DESCRIPTION
Path was `scripts/create_ami.sh` but the file lives at `shell/create_ami.sh` after the repo restructure. This is blocking today's AMI rebuild.