### PR TITLE
bump AMI version to 1.7.1

### DIFF
--- a/ami_version.yml
+++ b/ami_version.yml
@@ -1,4 +1,4 @@
-datastream-ami-version: "1.7.0"
+datastream-ami-version: "1.7.1"
 DS_TAG: "1.7.1"
 FP_TAG: "2.2.1"
 NGIAB_TAG: "v1.8.0"


### PR DESCRIPTION
Bumps datastream-ami-version to fire the AMI build workflow.