### PR TITLE
update lstm_0 AMI to DS 1.7.1 NGIAB v1.8.0

### DIFF
--- a/infra/aws/terraform/services/nrds/envs/prod.tfvars
+++ b/infra/aws/terraform/services/nrds/envs/prod.tfvars
@@ -24,7 +24,7 @@ scheduler_role_name   = "nrds_prod_scheduler_role"
 cfe_nom_ami_id      = "ami-038132f534157b5c3"
 fp_ami_id           = "ami-062245e1c9604128d"
 routing_only_ami_id = "ami-02cb92f166b83470e"
-lstm_0_ami_id       = "ami-038132f534157b5c3"
+lstm_0_ami_id       = "ami-0cd2a4414eceffdd8"
 restart_ami_id      = "ami-0e28d2f2d8491620b"
 
 # Schedule settings


### PR DESCRIPTION
Updates lstm_0_ami_id to ami-0cd2a4414eceffdd8 (datastream-1.7.0) built with DS_TAG=1.7.1, FP_TAG=2.2.1, NGIAB_TAG=v1.8.0.