### PR TITLE
checker: verify merkdir.file instead of removed ngen-run.tar.gz

### DIFF
--- a/infra/aws/terraform/modules/orchestration/lambdas/checker/lambda_function.py
+++ b/infra/aws/terraform/modules/orchestration/lambdas/checker/lambda_function.py
@@ -48,7 +48,7 @@ def lambda_handler(event, context):
             raise Exception(f'User specified ii_check_s3, but no s3_bucket or s3_prefix were not found in commands')
             
         if ii_ds_cmd:
-            prefix += "/ngen-run.tar.gz"
+            prefix += "/merkdir.file"
         else:
             prefix += "/metadata/forcings_metadata/metadata.csv"
         print(f'Checking if any objects with prefix {prefix} exists in {bucket}')


### PR DESCRIPTION
The datastream script no longer uploads `ngen-run.tar.gz` (#376), so the checker's success gate never passes and each ngen run burns its retries. `merkdir.file` is uploaded unconditionally on every S3 run by old and new scripts alike (verified in-script and via a live run). Fixes #380.